### PR TITLE
Pull DHCP Kea config from an S3 Bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ stop_development_environment:
 	docker-compose down -v
 
 run_development_environment: stop_development_environment
+	docker-compose up -d dhcp_config
 	docker-compose up -d db
 	./wait_for_db.sh
 	docker-compose up --build -d dhcp

--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y curl \
     apt-transport-https
 RUN curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-1-6/cfg/gpg/gpg.0607E2621F1564A6.key' | apt-key add -
 RUN curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-1-6/cfg/setup/config.deb.txt?distro=debian&codename=buster' > /etc/apt/sources.list.d/isc-kea-1-6.list
-RUN apt-get update && apt-get install -y isc-kea-* default-mysql-client
+RUN apt-get update && apt-get install -y isc-kea-* default-mysql-client wget
 
 WORKDIR /home
 RUN chown root:root /home

--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install -y isc-kea-* default-mysql-client wget
 
 WORKDIR /home
 RUN chown root:root /home
-COPY ./config.json /etc/kea/config.json
 COPY ./start_service.sh ./start_service.sh
 RUN  mkdir /var/run/kea
 

--- a/dhcp-service/start_service.sh
+++ b/dhcp-service/start_service.sh
@@ -6,7 +6,7 @@ if [ -n "$CONFIG_URL" ]; then
       echo "Fetching new config from ${CONFIG_URL}"
       wget -nv $CONFIG_URL -O /etc/kea/config.json
   else
-    echo "Using default config. New config not found"
+    echo "Using default config. Config at ${CONFIG_URL} not found"
   fi
 else
   echo "Using default config. No CONFIG_URL provided"

--- a/dhcp-service/start_service.sh
+++ b/dhcp-service/start_service.sh
@@ -1,5 +1,9 @@
 #! /bin/sh
 
+echo "Before fetching config file"
+wget https://staff-device-andy-dhcp-config-bucket.s3.eu-west-2.amazonaws.com/config.json -P /etc/kea
+echo "After fetching config file"
+
 sed -i "s/<INTERFACE>/$INTERFACE/g" /etc/kea/config.json
 sed -i "s/<DB_NAME>/$DB_NAME/g" /etc/kea/config.json
 sed -i "s/<DB_USER>/$DB_USER/g" /etc/kea/config.json

--- a/dhcp-service/start_service.sh
+++ b/dhcp-service/start_service.sh
@@ -1,8 +1,16 @@
 #! /bin/sh
 
-echo "Before fetching config file"
-wget https://staff-device-andy-dhcp-config-bucket.s3.eu-west-2.amazonaws.com/config.json -P /etc/kea
-echo "After fetching config file"
+if [ -z "$CONFIG_URL" ]; then
+  echo "Using default config. No CONFIG_URL provided"
+else
+  wget --quiet --spider $CONFIG_URL
+  if [ $? -eq 0 ] ; then
+      echo "Fetching new config from ${CONFIG_URL}"
+      wget -nv $CONFIG_URL -O /etc/kea/config.json
+  else
+    echo "Using default config. New config not found"
+  fi
+fi
 
 sed -i "s/<INTERFACE>/$INTERFACE/g" /etc/kea/config.json
 sed -i "s/<DB_NAME>/$DB_NAME/g" /etc/kea/config.json

--- a/dhcp-service/start_service.sh
+++ b/dhcp-service/start_service.sh
@@ -1,15 +1,19 @@
 #! /bin/sh
 
-if [ -n "$CONFIG_URL" ]; then
-    wget --quiet --spider $CONFIG_URL
+if [ -n "$KEA_CONFIG_URL" ]; then
+  echo "Checking for config at ${KEA_CONFIG_URL}"
+  wget --quiet --spider --timeout=60 $KEA_CONFIG_URL
+
   if [ $? -eq 0 ] ; then
-      echo "Fetching new config from ${CONFIG_URL}"
-      wget -nv $CONFIG_URL -O /etc/kea/config.json
+      echo "Found config. Fetching from ${KEA_CONFIG_URL}"
+      wget -nv --timeout=60 $KEA_CONFIG_URL -O /etc/kea/config.json
   else
-    echo "Using default config. Config at ${CONFIG_URL} not found"
+    echo "Config at ${KEA_CONFIG_URL} not found. Exiting."
+    exit 1
   fi
 else
-  echo "Using default config. No CONFIG_URL provided"
+  echo "No KEA_CONFIG_URL provided. Exiting"
+  exit 1
 fi
 
 sed -i "s/<INTERFACE>/$INTERFACE/g" /etc/kea/config.json

--- a/dhcp-service/start_service.sh
+++ b/dhcp-service/start_service.sh
@@ -1,15 +1,15 @@
 #! /bin/sh
 
-if [ -z "$CONFIG_URL" ]; then
-  echo "Using default config. No CONFIG_URL provided"
-else
-  wget --quiet --spider $CONFIG_URL
+if [ -n "$CONFIG_URL" ]; then
+    wget --quiet --spider $CONFIG_URL
   if [ $? -eq 0 ] ; then
       echo "Fetching new config from ${CONFIG_URL}"
       wget -nv $CONFIG_URL -O /etc/kea/config.json
   else
     echo "Using default config. New config not found"
   fi
+else
+  echo "Using default config. No CONFIG_URL provided"
 fi
 
 sed -i "s/<INTERFACE>/$INTERFACE/g" /etc/kea/config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,15 @@
 version: "3"
 services:
+  dhcp_config:
+    image: nginx:alpine
+    volumes:
+      - ${PWD}/dhcp-service/config.json:/usr/share/nginx/html/config.json
+    ports:
+      - 80:80
   dhcp:
     build: ./dhcp-service
     depends_on:
+      - dhcp_config
       - db
     environment:
       INTERFACE: eth0
@@ -11,6 +18,7 @@ services:
       DB_PASS: kea
       DB_HOST: db
       DB_PORT: 3306
+      KEA_CONFIG_URL: "dhcp_config/config.json"
     ports:
       - 67:67
       - 68:68

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       DB_PASS: kea
       DB_HOST: db
       DB_PORT: 3306
-      KEA_CONFIG_URL: "dhcp_config/config.json"
+      KEA_CONFIG_URL: "http://dhcp_config:80/config.json"
     ports:
       - 67:67
       - 68:68


### PR DESCRIPTION
Remove the default config and only use it in local development. Server the config file from nginx inside another docker container.

In production like environments use an S3 bucket that will be provisioned by terraform