### PR TITLE
Smoke test deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ make test
 
 This will first clear out any leases in the local database. We run `perfdhcp` to emulate a number of clients and multiple [DORA](https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol#Operation) cycles. We then check how many leases have been created to ensure the server is operating as expected. The `dhcp_test.sh` will exit with a non zero exit code if all of the leases have not been created.
 
+## Container Health Checks
+To ensure that an invalid task does not get into the production ecs cluster, a boostrap script has been writen. This uses ```perfdhcp``` to ensure that an IP can be leased. If this fails, a notification will be sent to the critical notifcation topic and forwarded to developers. This check is not done locally. 
 
 ## Manual Testing
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ To get started with development you will need:
 
 See the target `run` in the [Makefile](./Makefile)
 
-### `.env`
-In order to run this app locally you will need to create a `.env` file in the root of this project and add these variables to it.
-
-```
-ENVIRONMENT=development
-```
-
 ### Deploying to production
 
 Deployments are automated in the CI pipeline. See [buildspec.yml](./buildspec.yml)

--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y isc-kea-* default-mysql-client awscli
 
 WORKDIR /home
 RUN chown root:root /home
-COPY ./start_service.sh ./start_service.sh
+COPY ./bootstrap.sh ./bootstrap.sh
 COPY ./config.json ./test_config.json
 RUN  mkdir /var/run/kea
 
@@ -24,4 +24,4 @@ EXPOSE 80
 
 RUN service nginx start
 
-CMD ["./start_service.sh"]
+CMD ["./bootstrap.sh"]

--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -22,6 +22,4 @@ EXPOSE 67/udp
 EXPOSE 68/udp
 EXPOSE 80
 
-RUN service nginx start
-
 CMD ["./bootstrap.sh"]

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-
-set -m
+# -m for job control within a bash script (used to foreground server after testing)
+# -e for exiting script on any error
+set -mex
 
 run_acceptance_test() {
   perfdhcp -l lo $(hostname -i) -n 20 -r 2 -D 20% -R 10 > ./test_result
 }
 
 fetch_kea_config() {
-  if [[ -n $LOCAL_DEVELOPMENT ]]; then
+  if [ "$LOCAL_DEVELOPMENT" == "true" ]; then
     cp ./test_config.json /etc/kea/config.json
   else
     aws s3 cp s3://${KEA_CONFIG_BUCKET_NAME}/config.json /etc/kea/config.json
@@ -24,7 +25,9 @@ configure_database_credentials() {
 }
 
 init_schema_if_not_loaded() {
-  $(kea-admin db-init mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} &> /dev/null)
+  db_version=$(kea-admin db-version mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST}) 
+  echo $db_version
+  $(kea-admin db-init mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} &> /dev/null) 
 }
 
 boot_server() {
@@ -32,7 +35,7 @@ boot_server() {
 }
 
 ensure_healthy_server() {
-  received_packets=`cat ./test_result |grep "received packets: 0"`
+  received_packets=`cat ./test_result | grep "received packets: 0"`
 
   if ! [[ -z $received_packets ]]; then
     aws sns publish --topic-arn $CRITICAL_NOTIFICATIONS_ARN --message "DHCP server failed to boot" --region eu-west-2
@@ -45,8 +48,10 @@ main() {
   configure_database_credentials
   init_schema_if_not_loaded
   boot_server
-  run_acceptance_test
-  ensure_healthy_server
+  if ! [ "$LOCAL_DEVELOPMENT" == "true" ]; then
+    run_acceptance_test
+    ensure_healthy_server
+  fi 
   fg %1 #KEA is running as a daemon, bring it back as the essential task of the container now that testing is finished
 }
 

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -3,6 +3,10 @@
 # -e for exiting script on any error
 set -m
 
+start_nginx() {
+  service nginx start
+}
+
 run_acceptance_test() {
   perfdhcp -l lo $(hostname -i) -n 20 -r 2 -D 20% -R 10 > ./test_result
 }
@@ -46,6 +50,7 @@ ensure_healthy_server() {
 }
 
 main() {
+  start_nginx
   fetch_kea_config
   configure_database_credentials
   init_schema_if_not_loaded

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # -m for job control within a bash script (used to foreground server after testing)
 # -e for exiting script on any error
-set -mex
+set -me
 
 run_acceptance_test() {
   perfdhcp -l lo $(hostname -i) -n 20 -r 2 -D 20% -R 10 > ./test_result
@@ -25,9 +25,11 @@ configure_database_credentials() {
 }
 
 init_schema_if_not_loaded() {
-  db_version=$(kea-admin db-version mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST}) 
-  echo $db_version
-  $(kea-admin db-init mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} &> /dev/null) 
+  db_version=$(kea-admin db-version mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST})
+  if [ -z "$db_version" ]; then
+  echo " we are initting the db"
+    $(kea-admin db-init mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} &> /dev/null)
+  fi
 }
 
 boot_server() {
@@ -51,7 +53,7 @@ main() {
   if ! [ "$LOCAL_DEVELOPMENT" == "true" ]; then
     run_acceptance_test
     ensure_healthy_server
-  fi 
+  fi
   fg %1 #KEA is running as a daemon, bring it back as the essential task of the container now that testing is finished
 }
 

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # -m for job control within a bash script (used to foreground server after testing)
 # -e for exiting script on any error
-set -me
+set -m
 
 run_acceptance_test() {
   perfdhcp -l lo $(hostname -i) -n 20 -r 2 -D 20% -R 10 > ./test_result

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # -m for job control within a bash script (used to foreground server after testing)
-# -e for exiting script on any error
+# TODO: Add -e flag for erroring. This will cause the kea-admin command to error if the database exists.
 set -m
 
 start_nginx() {

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -31,7 +31,6 @@ configure_database_credentials() {
 init_schema_if_not_loaded() {
   db_version=$(kea-admin db-version mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST})
   if [ -z "$db_version" ]; then
-  echo " we are initting the db"
     $(kea-admin db-init mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} &> /dev/null)
   fi
 }

--- a/dhcp-service/dhcp_test.sh
+++ b/dhcp-service/dhcp_test.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/bin/bash
+set -e
 # echo "Sleeping to wait for kea..."
 # sleep 1
 

--- a/dhcp-service/dhcp_test.sh
+++ b/dhcp-service/dhcp_test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
+# -e for error output
 set -e
-# echo "Sleeping to wait for kea..."
-# sleep 1
 
 echo "Deleting database leases..."
 mysql --user=kea \

--- a/dhcp-service/start_service.sh
+++ b/dhcp-service/start_service.sh
@@ -1,18 +1,53 @@
-#! /bin/bash
+#!/bin/bash
 
-if [[ $ENVIRONMENT == "development" ]]; then
+set -m
+
+run_acceptance_test() {
+  perfdhcp -l lo $(hostname -i) -n 20 -r 2 -D 20% -R 10 > ./test_result
+}
+
+fetch_kea_config() {
+  if [[ -n $LOCAL_DEVELOPMENT ]]; then
     cp ./test_config.json /etc/kea/config.json
-else
+  else
     aws s3 cp s3://${KEA_CONFIG_BUCKET_NAME}/config.json /etc/kea/config.json
-fi
+  fi
+}
 
-sed -i "s/<INTERFACE>/$INTERFACE/g" /etc/kea/config.json
-sed -i "s/<DB_NAME>/$DB_NAME/g" /etc/kea/config.json
-sed -i "s/<DB_USER>/$DB_USER/g" /etc/kea/config.json
-sed -i "s/<DB_PASS>/$DB_PASS/g" /etc/kea/config.json
-sed -i "s/<DB_HOST>/$DB_HOST/g" /etc/kea/config.json
-sed -i "s/<DB_PORT>/$DB_PORT/g" /etc/kea/config.json
+configure_database_credentials() {
+  sed -i "s/<INTERFACE>/$INTERFACE/g" /etc/kea/config.json
+  sed -i "s/<DB_NAME>/$DB_NAME/g" /etc/kea/config.json
+  sed -i "s/<DB_USER>/$DB_USER/g" /etc/kea/config.json
+  sed -i "s/<DB_PASS>/$DB_PASS/g" /etc/kea/config.json
+  sed -i "s/<DB_HOST>/$DB_HOST/g" /etc/kea/config.json
+  sed -i "s/<DB_PORT>/$DB_PORT/g" /etc/kea/config.json
+}
 
-kea-admin db-init mysql -u $DB_USER -p $DB_PASS -n $DB_NAME -h $DB_HOST > /dev/null
-echo "Starting DHCP server..."
-kea-dhcp4 -c /etc/kea/config.json
+init_schema_if_not_loaded() {
+  $(kea-admin db-init mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} &> /dev/null)
+}
+
+boot_server() {
+  kea-dhcp4 -c /etc/kea/config.json &
+}
+
+ensure_healthy_server() {
+  received_packets=`cat ./test_result |grep "received packets: 0"`
+
+  if ! [[ -z $received_packets ]]; then
+    aws sns publish --topic-arn $CRITICAL_NOTIFICATIONS_ARN --message "DHCP server failed to boot" --region eu-west-2
+    exit 1
+  fi
+}
+
+main() {
+  fetch_kea_config
+  configure_database_credentials
+  init_schema_if_not_loaded
+  boot_server
+  run_acceptance_test
+  ensure_healthy_server
+  fg %1 #KEA is running as a daemon, bring it back as the essential task of the container now that testing is finished
+}
+
+main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
       - 67:67/udp
     volumes:
     - $HOME/.aws/credentials:/root/.aws/credentials:ro
-    env_file:
-      - ./.env
 
   dhcp-test:
     build: ./dhcp-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       DB_HOST: db
       DB_PORT: 3306
       KEA_CONFIG_BUCKET_NAME: "staff-device-andy-dhcp-config-bucket"
+      LOCAL_DEVELOPMENT: "true"
     ports:
       - 67:67/udp
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       DB_PASS: kea
       DB_HOST: db
       DB_PORT: 3306
-      KEA_CONFIG_BUCKET_NAME: "staff-device-andy-dhcp-config-bucket"
       LOCAL_DEVELOPMENT: "true"
     ports:
       - 67:67/udp


### PR DESCRIPTION
Implement end to end health checks

When a container is started on ECS, it will do a check first to see if
it can complete the DORA flow using perfDHCP. This test runs on the same
docker container as the server and will prevent the task from running if
the test was not successful.

This will prevent bad configuration taking down the entire cluster when
we implement zero downtime deployments.