### PR TITLE
Remove NGINX from the container

### DIFF
--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -2,10 +2,9 @@ FROM alpine:3.11
 
 ENV GLIBC_VER=2.31-r0
 
-RUN apk add bash curl nginx mysql mysql-client && \
+RUN apk add bash curl mysql mysql-client && \
     curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-1-8/cfg/setup/bash.alpine.sh' |  bash && \
     apk upgrade && apk add isc-kea-admin isc-kea-perfdhcp isc-kea-dhcp4 && \
-    mkdir -p /run/nginx && \
     curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub && \
     curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk && \
     curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk && \
@@ -24,6 +23,5 @@ COPY ./config.json ./test_config.json
 
 EXPOSE 67/udp
 EXPOSE 68/udp
-EXPOSE 80
 
 CMD ["./bootstrap.sh"]

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -55,11 +55,11 @@ main() {
   ensure_database_permissions
   init_schema_if_not_loaded
   boot_server
-  nginx &> /dev/null
   if ! [ "$LOCAL_DEVELOPMENT" == "true" ]; then
     run_acceptance_test
     ensure_healthy_server
   fi
+  touch /tmp/kea_started
   fg %1 #KEA is running as a daemon, bring it back as the essential task of the container now that testing is finished
 }
 

--- a/wait_for_dhcp_server.sh
+++ b/wait_for_dhcp_server.sh
@@ -2,7 +2,7 @@
 printf "Waiting for KEA DHCP server"
 
 count=0
-until docker-compose exec -T dhcp curl localhost &> /dev/null
+until docker-compose exec -T dhcp ls /tmp/kea_started 2> /dev/null
 do
   printf "."
   sleep 1


### PR DESCRIPTION
We use an NGINX container created in ECS so no need to manually install
here. Also modify the local health check in wait_for_dhcp_server.sh to
not rely on NGINX.