### PR TITLE
Spike exporting stats from DHCP server containers

### DIFF
--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -44,6 +44,14 @@ boot_server() {
   kea-dhcp4 -c /etc/kea/config.json &
 }
 
+export_server_stats() {
+  while true; do
+    curl --header "Content-Type: application/json" --request POST --data '{"service":["dhcp4"],"command":"statistic-get-all"}' localhost:8000
+
+    sleep 10
+  done
+}
+
 ensure_healthy_server() {
   received_packets=`cat ./test_result | grep "received packets: 0"`
 
@@ -65,6 +73,7 @@ main() {
     ensure_healthy_server
   fi
   touch /tmp/kea_started
+  export_server_stats
   fg %1 #KEA is running as a daemon, bring it back as the essential task of the container now that testing is finished
 }
 


### PR DESCRIPTION
This will go to CloudWatch where it can be made visible in Grafana.