### PR TITLE
Populate task id as a dimension for metrics

### DIFF
--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -6,7 +6,7 @@ ARG EXTRA_BUNDLE_CONFIG="without 'test'"
 RUN apk add bash curl mysql mysql-client && \
     curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-1-8/cfg/setup/bash.alpine.sh' |  bash && \
     apk upgrade && \
-    apk add ruby=2.6.6-r2 ruby-json=2.6.6-r2 ruby-dev isc-kea-admin isc-kea-perfdhcp isc-kea-dhcp4 isc-kea-ctrl-agent isc-kea-hook-lease-cmds isc-kea-hook-stat-cmds && \
+    apk add ruby=2.6.6-r2 ruby-json=2.6.6-r2 ruby-dev ruby-bigdecimal isc-kea-admin isc-kea-perfdhcp isc-kea-dhcp4 isc-kea-ctrl-agent isc-kea-hook-lease-cmds isc-kea-hook-stat-cmds && \
     curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub && \
     curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk && \
     curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk && \

--- a/dhcp-service/metrics/Gemfile
+++ b/dhcp-service/metrics/Gemfile
@@ -8,4 +8,5 @@ gem "aws-sdk-cloudwatch", "~>1.46"
 group :test do
   gem "rspec"
   gem "timecop"
+  gem "webmock"
 end

--- a/dhcp-service/metrics/boot_metrics_agent.rb
+++ b/dhcp-service/metrics/boot_metrics_agent.rb
@@ -3,6 +3,7 @@ require "net/http"
 require "json"
 require_relative "publish_metrics"
 require_relative "aws_client"
+require_relative "ecs_metadata_client"
 
 while true do
   uri = URI.parse("http://localhost:8000/")
@@ -12,7 +13,9 @@ while true do
   http = Net::HTTP.new(uri.host, uri.port)
   kea_stats = JSON.parse(http.request(req).body)
 
+  ecs_metadata_client = EcsMetadataClient.new(endpoint: ENV.fetch("ECS_CONTAINER_METADATA_URI"))
+
   p "KEA stats: #{kea_stats}"
-  PublishMetrics.new(client: AwsClient.new).execute(kea_stats: kea_stats)
+  PublishMetrics.new(client: AwsClient.new, ecs_metadata_client: ecs_metadata_client).execute(kea_stats: kea_stats)
   sleep 10
 end

--- a/dhcp-service/metrics/ecs_metadata_client.rb
+++ b/dhcp-service/metrics/ecs_metadata_client.rb
@@ -1,0 +1,28 @@
+require 'net/http'
+
+class EcsMetadataClient
+  def initialize(endpoint:)
+    @endpoint = endpoint
+  end
+
+  def execute
+    result = Net::HTTP.get(endpoint, '/v2/metadata')
+
+    payload(JSON.parse(result))
+  end
+
+  private
+
+  def payload(parsed_response)
+    containers_response = parsed_response.fetch("Containers")
+    container = containers_response.find do |container_response|
+      container_response.fetch("Name") == "dhcp-server"
+    end
+
+    {
+      task_id: container.fetch("DockerId")
+    }
+  end
+
+  attr_reader :endpoint
+end

--- a/dhcp-service/metrics/publish_metrics.rb
+++ b/dhcp-service/metrics/publish_metrics.rb
@@ -1,17 +1,19 @@
 require 'time'
 
 class PublishMetrics
-  def initialize(client:, aws_metadata_client:)
+  def initialize(client:, ecs_metadata_client:)
     @client = client
-    @aws_metadata_client = aws_metadata_client
+    @ecs_metadata_client = ecs_metadata_client
   end
 
   def execute(kea_stats:)
     raise "Kea stats are empty" if kea_stats.empty?
 
     client.put_metric_data(
-      with_percent_used(
-        generate_cloudwatch_metrics(kea_stats)
+      with_task_id(
+        with_percent_used(
+          generate_cloudwatch_metrics(kea_stats)
+        )
       )
     )
   end
@@ -35,12 +37,7 @@ class PublishMetrics
     date = values[0][1]
     time = DateTime.now.to_time.to_i
 
-    metric[:dimensions] = [
-      {
-        name: "TaskID",
-        value: task_id
-      }
-    ]
+    metric[:dimensions] = []
 
     if subnet_metric?(metric_name)
       metric_name = metric_name.split(".")[1]
@@ -79,10 +76,6 @@ class PublishMetrics
         metric_name: 'lease-percent-used',
         dimensions: [
         {
-          name: 'TaskID',
-          value: task_id,
-        },
-        {
           name: 'Subnet',
           value: k,
         }
@@ -96,7 +89,18 @@ class PublishMetrics
   end
 
   def task_id
-    @task_id ||= aws_metadata_client.execute.fetch(:task_id)
+    @task_id ||= ecs_metadata_client.execute.fetch(:task_id)
+  end
+
+  def with_task_id(metrics)
+    metrics.map do |metric|
+      metric[:dimensions] << {
+        name: "TaskID",
+        value: task_id
+      }
+
+      metric
+    end
   end
 
   IGNORED_METRICS = [
@@ -108,5 +112,5 @@ class PublishMetrics
     'reclaimed-declined-addresses',
     'reclaimed-leases'
   ]
-  attr_reader :client, :aws_metadata_client
+  attr_reader :client, :ecs_metadata_client
 end

--- a/dhcp-service/metrics/spec/ecs_metadata_client_spec.rb
+++ b/dhcp-service/metrics/spec/ecs_metadata_client_spec.rb
@@ -1,0 +1,20 @@
+require 'rspec'
+require 'webmock/rspec'
+require_relative '../ecs_metadata_client'
+
+describe EcsMetadataClient do
+  before do
+    ENV["ECS_CONTAINER_METADATA_URI"] = "169.254.170.2"
+
+    stub_request(:get, "#{ENV['ECS_CONTAINER_METADATA_URI']}/v2/metadata").
+    to_return(body: File.read("/metrics/spec/fixtures/ecs_container_metadata.json"))
+  end
+
+  it "fetches the task_id from the container metadata" do
+    expected_result = {
+      task_id: '731a0d6a3b4210e2448339bc7015aaa79bfe4fa256384f4102db86ef94cbbc4c'
+    }
+
+    expect(described_class.new(endpoint: ENV["ECS_CONTAINER_METADATA_URI"]).execute).to eq(expected_result)
+  end
+end

--- a/dhcp-service/metrics/spec/fixtures/ecs_container_metadata.json
+++ b/dhcp-service/metrics/spec/fixtures/ecs_container_metadata.json
@@ -1,0 +1,75 @@
+{
+  "Cluster": "default",
+  "TaskARN": "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+  "Family": "nginx",
+  "Revision": "5",
+  "DesiredStatus": "RUNNING",
+  "KnownStatus": "RUNNING",
+  "Containers": [
+    {
+      "DockerId": "731a0d6a3b4210e2448339bc7015aaa79bfe4fa256384f4102db86ef94cbbc4c",
+      "Name": "dhcp-server",
+      "DockerName": "ecs-nginx-5-internalecspause-acc699c0cbf2d6d11700",
+      "Image": "amazon/amazon-ecs-pause:0.1.0",
+      "ImageID": "",
+      "Labels": {
+        "com.amazonaws.ecs.cluster": "default",
+        "com.amazonaws.ecs.container-name": "~internal~ecs~pause",
+        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+        "com.amazonaws.ecs.task-definition-family": "nginx",
+        "com.amazonaws.ecs.task-definition-version": "5"
+      },
+      "DesiredStatus": "RESOURCES_PROVISIONED",
+      "KnownStatus": "RESOURCES_PROVISIONED",
+      "Limits": {
+        "CPU": 0,
+        "Memory": 0
+      },
+      "CreatedAt": "2018-02-01T20:55:08.366329616Z",
+      "StartedAt": "2018-02-01T20:55:09.058354915Z",
+      "Type": "CNI_PAUSE",
+      "Networks": [
+        {
+          "NetworkMode": "awsvpc",
+          "IPv4Addresses": [
+            "10.0.2.106"
+          ]
+        }
+      ]
+    },
+    {
+      "DockerId": "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+      "Name": "nginx",
+      "DockerName": "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+      "Image": "nrdlngr/nginx-curl",
+      "ImageID": "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+      "Labels": {
+        "com.amazonaws.ecs.cluster": "default",
+        "com.amazonaws.ecs.container-name": "nginx-curl",
+        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+        "com.amazonaws.ecs.task-definition-family": "nginx",
+        "com.amazonaws.ecs.task-definition-version": "5"
+      },
+      "DesiredStatus": "RUNNING",
+      "KnownStatus": "RUNNING",
+      "Limits": {
+        "CPU": 512,
+        "Memory": 512
+      },
+      "CreatedAt": "2018-02-01T20:55:10.554941919Z",
+      "StartedAt": "2018-02-01T20:55:11.064236631Z",
+      "Type": "NORMAL",
+      "Networks": [
+        {
+          "NetworkMode": "awsvpc",
+          "IPv4Addresses": [
+            "10.0.2.106"
+          ]
+        }
+      ]
+    }
+  ],
+  "PullStartedAt": "2018-02-01T20:55:09.372495529Z",
+  "PullStoppedAt": "2018-02-01T20:55:10.552018345Z",
+  "AvailabilityZone": "us-east-2b"
+}

--- a/dhcp-service/metrics/spec/kea_api_stats_response_minimal.json
+++ b/dhcp-service/metrics/spec/kea_api_stats_response_minimal.json
@@ -1,0 +1,13 @@
+[
+  {
+    "arguments": {
+      "cumulative-assigned-addresses": [
+        [
+          0,
+          "2020-11-09 11:33:29.855134"
+        ]
+      ]
+    },
+    "result": 0
+  }
+]

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -9,6 +9,7 @@ describe PublishMetrics do
   let(:kea_stats) { [] }
   let!(:time) { DateTime.now.to_time }
   let!(:timestamp) { time.to_i }
+  let(:aws_metadata_client) { double(execute: { task_id: "abc123" }) }
 
   before do
     Timecop.freeze(time)
@@ -19,94 +20,216 @@ describe PublishMetrics do
   end
 
   it 'raises an error if the kea stats is empty' do
-    expect { described_class.new(client: client).execute(kea_stats: kea_stats) }.to raise_error('Kea stats are empty')
+    expect {
+      described_class.new(client: client, aws_metadata_client: aws_metadata_client).execute(kea_stats: kea_stats)
+    }.to raise_error('Kea stats are empty')
   end
 
   it 'converts kea stats to cloudwatch metrics and calls the client to publish them' do
     kea_stats = JSON.parse(File.read("./metrics/spec/kea_api_stats_response.json"))
-    result = described_class.new(client: client).execute(kea_stats: kea_stats)
+    result = described_class.new(client: client, aws_metadata_client: aws_metadata_client).execute(kea_stats: kea_stats)
 
     expected_result = [
       {
         metric_name: "cumulative-assigned-addresses",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "declined-addresses",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-ack-received",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-ack-sent",
         timestamp: timestamp,
-        value: 18
+        value: 18,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-decline-received",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-discover-received",
         timestamp: timestamp,
-        value: 19
+        value: 19,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-inform-received",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-nak-received",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-nak-sent",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-offer-received",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-offer-sent",
         timestamp: timestamp,
-        value: 19
+        value: 19,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-parse-failed",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-receive-drop",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-received",
         timestamp: timestamp,
-        value: 37
+        value: 37,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-release-received",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-request-received",
         timestamp: timestamp,
-        value: 18
+        value: 18,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-sent",
         timestamp: timestamp,
-        value: 37
+        value: 37,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "pkt4-unknown-received",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "reclaimed-declined-addresses",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "reclaimed-leases",
         timestamp: timestamp,
-        value: 0
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "abc123",
+          }
+        ]
       }, {
         metric_name: "cumulative-assigned-addresses",
         timestamp: timestamp,
@@ -114,6 +237,10 @@ describe PublishMetrics do
         dimensions:
         [
           {
+            name: "TaskID",
+            value: "abc123"
+          },
+          {
             name: "Subnet",
             value: "1018"
           }
@@ -124,6 +251,10 @@ describe PublishMetrics do
         value: 0,
         dimensions:
         [
+          {
+            name: "TaskID",
+            value: "abc123",
+          },
           {
             name: "Subnet",
             value: "1018"
@@ -136,6 +267,10 @@ describe PublishMetrics do
         dimensions:
         [
           {
+            name: "TaskID",
+            value: "abc123",
+          },
+          {
             name: "Subnet",
             value: "1018"
           }
@@ -146,6 +281,10 @@ describe PublishMetrics do
         value: 0,
         dimensions:
         [
+          {
+            name: "TaskID",
+            value: "abc123",
+          },
           {
             name: "Subnet",
             value: "1018"
@@ -158,6 +297,10 @@ describe PublishMetrics do
         dimensions:
         [
           {
+            name: "TaskID",
+            value: "abc123",
+          },
+          {
             name: "Subnet",
             value: "1018"
           }
@@ -169,6 +312,10 @@ describe PublishMetrics do
         dimensions:
         [
           {
+            name: "TaskID",
+            value: "abc123",
+          },
+          {
             name: "Subnet",
             value: "1018"
           }
@@ -179,6 +326,10 @@ describe PublishMetrics do
         value: 10,
         dimensions:
         [
+          {
+            name: "TaskID",
+            value: "abc123",
+          },
           {
             name: "Subnet",
             value: "1"
@@ -191,6 +342,10 @@ describe PublishMetrics do
         dimensions:
           [
             {
+              name: "TaskID",
+              value: "abc123",
+            },
+            {
               name: "Subnet",
               value: "1"
             }
@@ -201,6 +356,10 @@ describe PublishMetrics do
         value: 0,
         dimensions:
         [
+          {
+            name: "TaskID",
+            value: "abc123",
+          },
           {
             name: "Subnet",
             value: "1"
@@ -213,6 +372,10 @@ describe PublishMetrics do
         dimensions:
         [
           {
+            name: "TaskID",
+            value: "abc123",
+          },
+          {
             name: "Subnet",
             value: "1"
           }
@@ -223,6 +386,10 @@ describe PublishMetrics do
         value: 0,
         dimensions:
         [
+          {
+            name: "TaskID",
+            value: "abc123",
+          },
           {
             name: "Subnet",
             value: "1"
@@ -235,6 +402,10 @@ describe PublishMetrics do
         dimensions:
         [
           {
+            name: "TaskID",
+            value: "abc123",
+          },
+          {
             name: "Subnet",
             value: "1"
           }
@@ -245,6 +416,10 @@ describe PublishMetrics do
         value: 10,
         dimensions:
         [
+          {
+            name: "TaskID",
+            value: "abc123",
+          },
           {
             name: "Subnet",
             value: "1018"
@@ -257,8 +432,35 @@ describe PublishMetrics do
         dimensions:
         [
           {
+            name: "TaskID",
+            value: "abc123",
+          },
+          {
             name: "Subnet",
             value: "1"
+          }
+        ]
+      }
+    ]
+
+    expect(client).to have_received(:put_metric_data).with(expected_result)
+  end
+
+  it 'uses a different task id' do
+    aws_metadata_client = double(execute: { task_id: "def789" })
+
+    kea_stats = JSON.parse(File.read("./metrics/spec/kea_api_stats_response_minimal.json"))
+    result = described_class.new(client: client, aws_metadata_client: aws_metadata_client).execute(kea_stats: kea_stats)
+
+    expected_result = [
+      {
+        metric_name: "cumulative-assigned-addresses",
+        timestamp: timestamp,
+        value: 0,
+        dimensions: [
+          {
+            name: "TaskID",
+            value: "def789",
           }
         ]
       }

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -9,7 +9,7 @@ describe PublishMetrics do
   let(:kea_stats) { [] }
   let!(:time) { DateTime.now.to_time }
   let!(:timestamp) { time.to_i }
-  let(:aws_metadata_client) { double(execute: { task_id: "abc123" }) }
+  let(:ecs_metadata_client) { double(execute: { task_id: "abc123" }) }
 
   before do
     Timecop.freeze(time)
@@ -21,13 +21,13 @@ describe PublishMetrics do
 
   it 'raises an error if the kea stats is empty' do
     expect {
-      described_class.new(client: client, aws_metadata_client: aws_metadata_client).execute(kea_stats: kea_stats)
+      described_class.new(client: client, ecs_metadata_client: ecs_metadata_client).execute(kea_stats: kea_stats)
     }.to raise_error('Kea stats are empty')
   end
 
   it 'converts kea stats to cloudwatch metrics and calls the client to publish them' do
     kea_stats = JSON.parse(File.read("./metrics/spec/kea_api_stats_response.json"))
-    result = described_class.new(client: client, aws_metadata_client: aws_metadata_client).execute(kea_stats: kea_stats)
+    result = described_class.new(client: client, ecs_metadata_client: ecs_metadata_client).execute(kea_stats: kea_stats)
 
     expected_result = [
       {
@@ -237,12 +237,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123"
-          },
-          {
             name: "Subnet",
             value: "1018"
+          },
+          {
+            name: "TaskID",
+            value: "abc123"
           }
         ]
       }, {
@@ -252,12 +252,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1018"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -267,12 +267,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1018"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -282,12 +282,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1018"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -297,12 +297,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1018"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -312,12 +312,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1018"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -327,12 +327,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -342,12 +342,12 @@ describe PublishMetrics do
         dimensions:
           [
             {
-              name: "TaskID",
-              value: "abc123",
-            },
-            {
               name: "Subnet",
               value: "1"
+            },
+            {
+              name: "TaskID",
+              value: "abc123",
             }
           ]
       }, {
@@ -357,12 +357,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -372,12 +372,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -387,12 +387,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -402,12 +402,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -417,12 +417,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1018"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }, {
@@ -432,12 +432,12 @@ describe PublishMetrics do
         dimensions:
         [
           {
-            name: "TaskID",
-            value: "abc123",
-          },
-          {
             name: "Subnet",
             value: "1"
+          },
+          {
+            name: "TaskID",
+            value: "abc123",
           }
         ]
       }
@@ -447,10 +447,10 @@ describe PublishMetrics do
   end
 
   it 'uses a different task id' do
-    aws_metadata_client = double(execute: { task_id: "def789" })
+    ecs_metadata_client = double(execute: { task_id: "def789" })
 
     kea_stats = JSON.parse(File.read("./metrics/spec/kea_api_stats_response_minimal.json"))
-    result = described_class.new(client: client, aws_metadata_client: aws_metadata_client).execute(kea_stats: kea_stats)
+    result = described_class.new(client: client, ecs_metadata_client: ecs_metadata_client).execute(kea_stats: kea_stats)
 
     expected_result = [
       {


### PR DESCRIPTION
We want to be able to aggregate based on task IDs, we need to populate
this information in our Cloudwatch metrics.

To get the task ID of a container running on ECS we have to read the
contents of a special file on the container.