### PR TITLE
Publish metrics with subnet ranges instead of IDs

### DIFF
--- a/dhcp-service/metrics/boot_metrics_agent.rb
+++ b/dhcp-service/metrics/boot_metrics_agent.rb
@@ -6,17 +6,19 @@ require_relative "aws_client"
 require_relative "ecs_metadata_client"
 require_relative "kea_client"
 require_relative "kea_lease_usage"
+require_relative "subnet_id_to_range_mapping"
 
 while true do
   kea_stats = KeaClient.new.get_statistics
   ecs_metadata_client = EcsMetadataClient.new(endpoint: ENV.fetch("ECS_CONTAINER_METADATA_URI"))
   kea_lease_usage = KeaLeaseUsage.new(kea_client: KeaClient.new)
+  subnet_id_to_range_mapping = SubnetIdToRangeMapping.new(config_api_client: KeaClient.new)
 
-  p "KEA stats: #{kea_stats}"
   PublishMetrics.new(
     client: AwsClient.new,
      ecs_metadata_client: ecs_metadata_client,
      kea_lease_usage: kea_lease_usage,
+    subnet_id_to_range_mapping: subnet_id_to_range_mapping
     ).execute(kea_stats: kea_stats)
   sleep 10
 end

--- a/dhcp-service/metrics/kea_client.rb
+++ b/dhcp-service/metrics/kea_client.rb
@@ -15,4 +15,9 @@ class KeaClient
     @req.body = { command: "statistic-get-all", service: ["dhcp4"] }.to_json
     JSON.parse(@http.request(@req).body)
   end
+
+  def get_config
+    @req.body = { command: "config-get", service: ["dhcp4"] }.to_json
+    JSON.parse(@http.request(@req).body)
+  end
 end

--- a/dhcp-service/metrics/publish_metrics.rb
+++ b/dhcp-service/metrics/publish_metrics.rb
@@ -1,11 +1,12 @@
 require 'time'
 
 class PublishMetrics
-  def initialize(client:, ecs_metadata_client:, kea_lease_usage:)
+  def initialize(client:, ecs_metadata_client:, kea_lease_usage:, subnet_id_to_range_mapping:)
     @client = client
     @ecs_metadata_client = ecs_metadata_client
     @kea_lease_usage = kea_lease_usage
     @time = DateTime.now.to_time.to_i
+    @subnet_id_to_range_mapping = subnet_id_to_range_mapping
   end
 
   def execute(kea_stats:)
@@ -36,7 +37,7 @@ class PublishMetrics
 
     if subnet_metric?(metric_name)
       metric_name = metric_name.split(".")[1]
-      metric[:dimensions] << { name: "Subnet", value: row[0][/\d+/] }
+      metric[:dimensions] << { name: "Subnet", value: subnet_id_to_range(row[0][/\d+/].to_i) }
       metric[:timestamp] = @time
     end
 
@@ -45,6 +46,14 @@ class PublishMetrics
     metric[:value] = value
 
     metric
+  end
+
+  def subnet_id_to_range_map
+    @subnet_id_to_range_map ||= subnet_id_to_range_mapping.execute
+  end
+
+  def subnet_id_to_range(subnet_id)
+    subnet_id_to_range_map.find { |mapping| subnet_id == mapping[:id] }[:subnet]
   end
 
   def task_id
@@ -71,12 +80,12 @@ class PublishMetrics
         metric_name: "lease-percent-used",
         timestamp: @time,
         value: kea_metric.fetch(:usage_percentage),
-        dimensions: [ { name: "Subnet", value: kea_metric.fetch(:subnet_id).to_s } ]
+        dimensions: [ { name: "Subnet", value: subnet_id_to_range(kea_metric.fetch(:subnet_id).to_i) } ]
       }
     end
 
     metrics
   end
 
-  attr_reader :client, :ecs_metadata_client, :kea_lease_usage
+  attr_reader :client, :ecs_metadata_client, :kea_lease_usage, :subnet_id_to_range_mapping
 end

--- a/dhcp-service/metrics/spec/kea_client_spec.rb
+++ b/dhcp-service/metrics/spec/kea_client_spec.rb
@@ -11,6 +11,11 @@ describe KeaClient do
       with(
         body: "{\"command\":\"statistic-get-all\",\"service\":[\"dhcp4\"]}"
       ).to_return(status: 200, body: "{}", headers: {})
+
+    stub_request(:post, "http://localhost:8000/").
+      with(
+        body: "{\"command\":\"config-get\",\"service\":[\"dhcp4\"]}"
+    ).to_return(status: 200, body: "{}", headers: {})
   end
 
   it "gets leases" do
@@ -19,5 +24,9 @@ describe KeaClient do
 
   it "gets statistics" do
     described_class.new.get_statistics
+  end
+
+  it "gets configuration" do
+    described_class.new.get_config
   end
 end

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -28,6 +28,18 @@ describe PublishMetrics do
       ])
   end
 
+  let(:subnet_id_to_range_mapping) do
+    double(execute: [
+        {
+          id: 1018,
+          subnet: "127.0.0.1/16"
+        }, {
+          id: 1,
+          subnet: "10.0.0.1/16"
+        }
+      ])
+  end
+
   before do
     Timecop.freeze(time)
   end
@@ -41,7 +53,8 @@ describe PublishMetrics do
       described_class.new(
         client: client,
         ecs_metadata_client: ecs_metadata_client,
-        kea_lease_usage: kea_lease_usage
+        kea_lease_usage: kea_lease_usage,
+        subnet_id_to_range_mapping: subnet_id_to_range_mapping
       ).execute(kea_stats: kea_stats)
     }.to raise_error('Kea stats are empty')
   end
@@ -52,7 +65,8 @@ describe PublishMetrics do
     result = described_class.new(
       client: client,
       ecs_metadata_client: ecs_metadata_client,
-      kea_lease_usage: kea_lease_usage
+      kea_lease_usage: kea_lease_usage,
+      subnet_id_to_range_mapping: subnet_id_to_range_mapping
     ).execute(kea_stats: kea_stats)
 
     expected_result = [
@@ -264,7 +278,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1018"
+            value: "127.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -279,7 +293,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1018"
+            value: "127.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -294,7 +308,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1018"
+            value: "127.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -309,7 +323,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1018"
+            value: "127.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -324,7 +338,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1018"
+            value: "127.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -339,7 +353,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1018"
+            value: "127.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -354,7 +368,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1"
+            value: "10.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -369,7 +383,7 @@ describe PublishMetrics do
           [
             {
               name: "Subnet",
-              value: "1"
+              value: "10.0.0.1/16"
             },
             {
               name: "TaskID",
@@ -384,7 +398,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1"
+            value: "10.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -399,7 +413,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1"
+            value: "10.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -414,7 +428,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1"
+            value: "10.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -429,7 +443,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1"
+            value: "10.0.0.1/16"
           },
           {
             name: "TaskID",
@@ -444,7 +458,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1"
+            value: "10.0.0.1/16"
           }
         ]
       }, {
@@ -455,7 +469,7 @@ describe PublishMetrics do
         [
           {
             name: "Subnet",
-            value: "1018"
+            value: "127.0.0.1/16"
           }
         ]
       }
@@ -471,7 +485,8 @@ describe PublishMetrics do
     result = described_class.new(
       client: client,
       ecs_metadata_client: ecs_metadata_client,
-      kea_lease_usage: kea_lease_usage
+      kea_lease_usage: kea_lease_usage,
+      subnet_id_to_range_mapping: subnet_id_to_range_mapping
     ).execute(kea_stats: kea_stats)
 
     expected_result = [
@@ -489,7 +504,7 @@ describe PublishMetrics do
       dimensions: [
         {
           name: "Subnet",
-          value: "1"
+          value: "10.0.0.1/16"
         }
         ],
         metric_name: "lease-percent-used",
@@ -500,7 +515,7 @@ describe PublishMetrics do
         dimensions: [
           {
             name: "Subnet",
-            value:"1018"
+            value:"127.0.0.1/16"
           }
         ],
         metric_name: "lease-percent-used",

--- a/dhcp-service/metrics/spec/subnet_id_to_range_spec.rb
+++ b/dhcp-service/metrics/spec/subnet_id_to_range_spec.rb
@@ -1,0 +1,20 @@
+require_relative "../subnet_id_to_range_mapping"
+
+describe SubnetIdToRangeMapping do
+  it "maps a subnet ID to a subnet range" do
+    config_api_client = double(get_config: JSON.parse(File.read("/metrics/spec/fixtures/kea_api_config_get_response.json")))
+    result = described_class.new(config_api_client: config_api_client).execute
+
+    expect(result).to eq(
+      [
+        {
+          id: 1,
+          subnet: "127.0.0.1/16"
+        }, {
+          id: 2,
+          subnet: "10.0.0.1/16"
+        }
+      ]
+    )
+  end
+end

--- a/dhcp-service/metrics/subnet_id_to_range_mapping.rb
+++ b/dhcp-service/metrics/subnet_id_to_range_mapping.rb
@@ -1,0 +1,27 @@
+require 'json'
+
+class SubnetIdToRangeMapping
+  def initialize(config_api_client:)
+    @config_api_client = config_api_client
+  end
+
+  def execute
+    kea_config = config_api_client.get_config
+    payload(kea_config)
+  end
+
+  private
+
+  def payload(kea_config)
+    subnet_config = kea_config[0].fetch("arguments").fetch("Dhcp4").fetch("subnet4")
+
+    subnet_config.map do |config|
+      {
+        id: config.fetch("id"),
+        subnet: config.fetch("subnet")
+      }
+    end
+  end
+
+  attr_reader :config_api_client
+end


### PR DESCRIPTION
This will show up in Grafana as ranges which is more useful for admins
to see.