### PR TITLE
Set multi threading in the test config

### DIFF
--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -19,8 +19,7 @@ RUN apk add bash curl mysql mysql-client && \
   rm glibc-${GLIBC_VER}.apk && \
   rm glibc-bin-${GLIBC_VER}.apk && \
   rm -rf /var/cache/apk/* && \
-  cp -r usr/share/kea/kea/scripts/ usr/share/kea/ && \
-  gem install bundler
+  cp -r usr/share/kea/kea/scripts/ usr/share/kea/
 
 COPY ./bootstrap.sh ./bootstrap.sh
 COPY ./config.json ./test_config.json

--- a/dhcp-service/config.json
+++ b/dhcp-service/config.json
@@ -107,6 +107,13 @@
       {
         "library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"
       }
-    ]
+    ],
+    // Multi threaded config for a mysql backend
+    // https://kea.readthedocs.io/en/kea-1.8.0/arm/dhcp4-srv.html#multi-threading-settings-in-different-backends
+    "multi-threading": {
+       "enable-multi-threading": true,
+       "thread-pool-size": 12,
+       "packet-queue-size": 792
+    }
   }
 }


### PR DESCRIPTION
Enabled multi threading in the test config to ensure that our test pipeline passes when multi threading is enabled (to simulate production)