### PR TITLE
Ignore non subnet specific sum metrics

### DIFF
--- a/dhcp-service/metrics/publish_metrics.rb
+++ b/dhcp-service/metrics/publish_metrics.rb
@@ -32,6 +32,8 @@ class PublishMetrics
     value = values[0][0]
     date = values[0][1]
 
+    return if IGNORED_METRICS.include?(metric_name)
+
     metric[:dimensions] = []
 
     if subnet_metric?(metric_name)
@@ -71,6 +73,17 @@ class PublishMetrics
 
     metrics
   end
+
+  IGNORED_METRICS = [
+    "cumulative-assigned-addresses",
+    "pkt4-sent",
+    "pkt4-received",
+    "cumulative-assigned-addresses",
+    "declined-addresses",
+    "declined-reclaimed-addresses",
+    "reclaimed-declined-addresses",
+    "reclaimed-leases"
+  ]
 
   attr_reader :client, :kea_lease_usage, :kea_subnet_id_to_cidr
 end

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -61,16 +61,6 @@ describe PublishMetrics do
 
     expected_result = [
       {
-        metric_name: "cumulative-assigned-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions: []
-      }, {
-        metric_name: "declined-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions: []
-      }, {
         metric_name: "pkt4-ack-received",
         timestamp: timestamp,
         value: 0,
@@ -126,11 +116,6 @@ describe PublishMetrics do
         value: 0,
         dimensions: []
       }, {
-        metric_name: "pkt4-received",
-        timestamp: timestamp,
-        value: 37,
-        dimensions: []
-      }, {
         metric_name: "pkt4-release-received",
         timestamp: timestamp,
         value: 0,
@@ -141,22 +126,7 @@ describe PublishMetrics do
         value: 18,
         dimensions: []
       }, {
-        metric_name: "pkt4-sent",
-        timestamp: timestamp,
-        value: 37,
-        dimensions: []
-      }, {
         metric_name: "pkt4-unknown-received",
-        timestamp: timestamp,
-        value: 0,
-        dimensions: []
-      }, {
-        metric_name: "reclaimed-declined-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions: []
-      }, {
-        metric_name: "reclaimed-leases",
         timestamp: timestamp,
         value: 0,
         dimensions: []
@@ -330,12 +300,7 @@ describe PublishMetrics do
     ).execute(kea_stats: kea_stats)
 
     expected_result = [
-      {
-        metric_name: "cumulative-assigned-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions: []
-      },{
+     {
       dimensions: [
         {
           name: "Subnet",


### PR DESCRIPTION
These metrics are already published by subnet, no need to publish the
global values for these metrics.