### PR TITLE
Add KEA config file for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ stop:
 	$(DOCKER_COMPOSE) down -v
 
 run: start-db
-	$(DOCKER_COMPOSE) up -d dhcp
+	$(DOCKER_COMPOSE) up -d dhcp-primary
+	./wait_for_dhcp_server.sh
+	$(DOCKER_COMPOSE) up -d dhcp-standby
 
 test: run build-dev
 	./wait_for_dhcp_server.sh
@@ -47,7 +49,7 @@ test: run build-dev
 	$(DOCKER_COMPOSE) run --rm dhcp-test bash ./dhcp_test.sh
 
 shell: start-db
-	$(DOCKER_COMPOSE) run --rm dhcp sh
+	$(DOCKER_COMPOSE) run --rm dhcp-primary sh
 
 shell-test: start-db
 	$(DOCKER_COMPOSE) run --rm dhcp-test sh

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -68,10 +68,12 @@ main() {
   init_schema_if_not_loaded
   boot_control_agent
   boot_server
-  # if ! [ "$LOCAL_DEVELOPMENT" == "true" ]; then
-  #   run_acceptance_test
-  #   ensure_healthy_server
-  # fi
+
+  if [[ "$SERVER_NAME" == "primary" ]]; then
+    run_acceptance_test
+    ensure_healthy_server
+  fi
+
   touch /tmp/kea_started
   boot_metrics_agent
   fg %2 #KEA is running as a daemon, bring it back as the essential task of the container now that testing is finished

--- a/dhcp-service/config.json
+++ b/dhcp-service/config.json
@@ -97,7 +97,8 @@
             "output": "stdout"
           }
         ],
-        "severity": "DEBUG"
+        "severity": "DEBUG",
+        "debuglevel": 0
       }
     ],
     "hooks-libraries": [
@@ -114,20 +115,22 @@
             {
               "this-server-name": "<SERVER_NAME>",
               "mode": "hot-standby",
-              "heartbeat-delay": 10000,
-              "max-response-delay": 10000,
-              "max-ack-delay": 5000,
+              "heartbeat-delay": 10,
+              "max-response-delay": 10,
+              "max-ack-delay": 10,
               "max-unacked-clients": 5,
               "peers": [
                 {
                   "name": "primary",
                   "url": "http://<PRIMARY_IP>:8000",
-                  "role": "primary"
+                  "role": "primary",
+                  "auto-failover": true
                 },
                 {
                   "name": "standby",
                   "url": "http://<STANDBY_IP>:8000",
-                  "role": "standby"
+                  "role": "standby",
+                  "auto-failover": true
                 }
               ]
             }

--- a/dhcp-service/config.json
+++ b/dhcp-service/config.json
@@ -106,6 +106,33 @@
       },
       {
         "library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"
+      },
+      {
+        "library": "/usr/lib/kea/hooks/libdhcp_ha.so",
+        "parameters": {
+          "high-availability": [
+            {
+              "this-server-name": "<SERVER_NAME>",
+              "mode": "hot-standby",
+              "heartbeat-delay": 10000,
+              "max-response-delay": 10000,
+              "max-ack-delay": 5000,
+              "max-unacked-clients": 5,
+              "peers": [
+                {
+                  "name": "primary",
+                  "url": "http://<PRIMARY_IP>:8000",
+                  "role": "primary"
+                },
+                {
+                  "name": "standby",
+                  "url": "http://<STANDBY_IP>:8000",
+                  "role": "standby"
+                }
+              ]
+            }
+          ]
+        }
       }
     ],
     // Multi threaded config for a mysql backend

--- a/dhcp-service/dhcp_test.sh
+++ b/dhcp-service/dhcp_test.sh
@@ -14,12 +14,13 @@ echo "Running perfdhcp..."
 # -d drop-time
 # -W exit-wait-time
 number_of_clients=10
-perfdhcp -r 10 \
+
+perfdhcp -r 2 \
          -n $number_of_clients \
          -R $number_of_clients \
          -d 2 \
-         -W 10000 \
-         172.1.0.3
+         -W 100000 \
+         172.1.0.10
 
 echo "Checking leases created..."
 count=$(mysql --user=kea --password=kea --host=db --database=kea --silent --silent --skip-column-names --execute "SELECT count(*) FROM lease4;")

--- a/dhcp-service/dhcp_test.sh
+++ b/dhcp-service/dhcp_test.sh
@@ -19,7 +19,7 @@ perfdhcp -r 2 \
          -n $number_of_clients \
          -R $number_of_clients \
          -d 2 \
-         -W 100000 \
+         -W 1000000 \
          172.1.0.10
 
 echo "Checking leases created..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
-  dhcp:
+  dhcp-primary:
     build:
       context: ./dhcp-service
       args:
@@ -16,14 +16,40 @@ services:
       DB_PORT: 3306
       LOCAL_DEVELOPMENT: "true"
       SERVER_NAME: "primary"
-      PRIMARY_IP: "127.0.0.1"
-      STANDBY_IP: "128.0.0.2"
+      PRIMARY_IP: "172.1.0.10"
+      STANDBY_IP: "172.1.0.11"
     ports:
       - 67:67/udp
       - 8000:8000
     volumes:
       - $HOME/.aws/credentials:/root/.aws/credentials:ro
       - ./dhcp-service/metrics/:/metrics
+    networks:
+      default:
+        ipv4_address: 172.1.0.10
+
+  dhcp-standby:
+    build:
+      context: ./dhcp-service
+      args:
+        SHARED_SERVICES_ACCOUNT_ID: "${SHARED_SERVICES_ACCOUNT_ID}"
+    environment:
+      INTERFACE: eth0
+      DB_NAME: kea
+      DB_USER: kea
+      DB_PASS: kea
+      DB_HOST: db
+      DB_PORT: 3306
+      LOCAL_DEVELOPMENT: "true"
+      SERVER_NAME: "standby"
+      PRIMARY_IP: "172.1.0.10"
+      STANDBY_IP: "172.1.0.11"
+    volumes:
+      - $HOME/.aws/credentials:/root/.aws/credentials:ro
+      - ./dhcp-service/metrics/:/metrics
+    networks:
+      default:
+        ipv4_address: 172.1.0.11
 
   dhcp-test:
     build:
@@ -33,7 +59,7 @@ services:
         EXTRA_BUNDLE_CONFIG: ""
     depends_on:
       - db
-      - dhcp
+      - dhcp-primary
     ports:
       - 68:68/udp
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       DB_HOST: db
       DB_PORT: 3306
       LOCAL_DEVELOPMENT: "true"
+      SERVER_NAME: "primary"
+      PRIMARY_IP: "127.0.0.1"
+      STANDBY_IP: "128.0.0.2"
     ports:
       - 67:67/udp
       - 8000:8000

--- a/wait_for_dhcp_server.sh
+++ b/wait_for_dhcp_server.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-printf "Waiting for KEA DHCP server"
+printf "Waiting for Primary KEA DHCP server"
 
 count=0
-until docker-compose exec -T dhcp ls /tmp/kea_started 2> /dev/null
+until docker-compose exec -T dhcp-primary ls /tmp/kea_started 2> /dev/null
 do
   printf "."
   sleep 1


### PR DESCRIPTION
Update the configuration file to reflect HA running in production.
Our local server will boot as primary.

Docker compose doesn't allow exposing the same port (8000) for both the primary and standby servers locally.
This prevents booting up both primary and standby locally, unless another port is. Our dockerfile currently only listens on port 8000