### PR TITLE
Zero downtime deployments for KEA HA

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,11 +16,26 @@ assume_deploy_role() {
 
 deploy() {
   cluster_name=$( jq -r '.dhcp.ecs.cluster_name' <<< "${DHCP_DNS_TERRAFORM_OUTPUTS}" )
-  service_name=$( jq -r '.dhcp.ecs.service_name' <<< "${DHCP_DNS_TERRAFORM_OUTPUTS}" )
+  primary_service_name=$( jq -r '.dhcp.ecs.service_name' <<< "${DHCP_DNS_TERRAFORM_OUTPUTS}" )
+  standby_service_name=$( jq -r '.dhcp_standby.ecs.service_name' <<< "${DHCP_DNS_TERRAFORM_OUTPUTS}" )
+  api_service_name=$( jq -r '.dhcp_api.ecs.service_name' <<< "${DHCP_DNS_TERRAFORM_OUTPUTS}" )
 
+  echo "deploying KEA Standby"
   aws ecs update-service \
     --cluster $cluster_name \
-    --service $service_name \
+    --service $standby_service_name \
+    --force-new-deployment
+
+  echo "deploying KEA API"
+  aws ecs update-service \
+    --cluster $cluster_name \
+    --service $api_service_name \
+    --force-new-deployment
+
+  echo "deploying KEA PRIMARY"
+  aws ecs update-service \
+    --cluster $cluster_name \
+    --service $primary_service_name \
     --force-new-deployment
 }
 


### PR DESCRIPTION
After the container has been pushed to ecr, this script will start a
zero downtime deployment of the following services:

1. KEA Standby
2. KEA API
3. KEA Primary

It will double the task count and then scale it back in gracefully so
the new servers can take over traffic.

Tested with perfdhcp and this doesn't cause any downtime or
complications with peer heartbeats or lease syncs.