### PR TITLE
Add dependabot for metrics gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/dhcp-service/metrics"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This will keep the dependencies up to date by creating pull requests.