### PR TITLE
Only publish metrics for Primary and Standby servers

### DIFF
--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -83,7 +83,9 @@ main() {
   boot_control_agent
   boot_server
   touch /tmp/kea_started
-  boot_metrics_agent
+  if [[ "$SERVER_NAME" == "primary" || "$SERVER_NAME" == "standby" ]]; then
+    boot_metrics_agent
+  fi
   start_kea_config_reload_daemon
   fg %2 #KEA is running as a daemon, bring it back as the essential task of the container now that testing is finished
 }


### PR DESCRIPTION
We don't need to publish metrics from the API, suppress this by looking at the server name.