### PR TITLE
Remove subnet dimensions from metrics

### DIFF
--- a/dhcp-service/metrics/aws_client.rb
+++ b/dhcp-service/metrics/aws_client.rb
@@ -11,7 +11,7 @@ class AwsClient
   def put_metric_data(metrics)
     sliced(metrics).each do |metrics_slice|
       client.put_metric_data(
-        namespace: "DHCP-Kea-Server",
+        namespace: "DHCP-Kea-Service",
         metric_data: metrics_slice
       )
     end

--- a/dhcp-service/metrics/publish_metrics.rb
+++ b/dhcp-service/metrics/publish_metrics.rb
@@ -55,12 +55,6 @@ class PublishMetrics
   end
 
   def with_percent_used(metrics)
-    percent_used_subnet_metrics = metrics.select do |metric|
-      metric[:metric_name] == 'total-addresses'
-    end.group_by do |metric|
-      metric[:dimensions].select { |d| d[:name] == 'Subnet' }.first[:value]
-    end
-
     kea_lease_usage.execute.each do |kea_metric|
       subnet_cidr = subnet_id_to_cidr(kea_metric.fetch(:subnet_id))
       metrics << {

--- a/dhcp-service/metrics/publish_metrics.rb
+++ b/dhcp-service/metrics/publish_metrics.rb
@@ -32,17 +32,9 @@ class PublishMetrics
     value = values[0][0]
     date = values[0][1]
 
-    return if IGNORED_METRICS.include?(metric_name)
+    return if IGNORED_METRICS.include?(metric_name) or subnet_metric?(metric_name)
 
     metric[:dimensions] = []
-
-    if subnet_metric?(metric_name)
-      subnet_cidr = subnet_id_to_cidr(row[0][/\d+/])
-      metric_name = metric_name.split(".")[1]
-      metric[:dimensions] << { name: "Subnet", value: subnet_cidr }
-      metric[:timestamp] = @time
-    end
-
     metric[:metric_name] = metric_name
     metric[:timestamp] = @time
     metric[:value] = value
@@ -69,14 +61,12 @@ class PublishMetrics
   end
 
   IGNORED_METRICS = [
-    "cumulative-assigned-addresses",
     "pkt4-sent",
+    "pkt4-inform-received",
+    "pkt4-parse-failed",
     "pkt4-received",
-    "cumulative-assigned-addresses",
-    "declined-addresses",
     "declined-reclaimed-addresses",
-    "reclaimed-declined-addresses",
-    "reclaimed-leases"
+    "total-addresses"
   ]
 
   attr_reader :client, :kea_lease_usage, :kea_subnet_id_to_cidr

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -60,7 +60,17 @@ describe PublishMetrics do
     ).execute(kea_stats: kea_stats)
 
     expected_result = [
-      {
+    {
+        metric_name: "cumulative-assigned-addresses",
+        timestamp: timestamp,
+        value: 0,
+        dimensions: []
+      }, {
+        metric_name: "declined-addresses",
+        timestamp: timestamp,
+        value: 0,
+        dimensions: []
+      }, {
         metric_name: "pkt4-ack-received",
         timestamp: timestamp,
         value: 0,
@@ -79,11 +89,6 @@ describe PublishMetrics do
         metric_name: "pkt4-discover-received",
         timestamp: timestamp,
         value: 19,
-        dimensions: []
-      }, {
-        metric_name: "pkt4-inform-received",
-        timestamp: timestamp,
-        value: 0,
         dimensions: []
       }, {
         metric_name: "pkt4-nak-received",
@@ -106,11 +111,6 @@ describe PublishMetrics do
         value: 19,
         dimensions: []
       }, {
-        metric_name: "pkt4-parse-failed",
-        timestamp: timestamp,
-        value: 0,
-        dimensions: []
-      }, {
         metric_name: "pkt4-receive-drop",
         timestamp: timestamp,
         value: 0,
@@ -131,137 +131,15 @@ describe PublishMetrics do
         value: 0,
         dimensions: []
       }, {
-        metric_name: "cumulative-assigned-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "192.0.2.0/24"
-          }
-        ]
-      }, {
-        metric_name: "declined-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "192.0.2.0/24"
-          }
-        ]
-      }, {
         metric_name: "reclaimed-declined-addresses",
         timestamp: timestamp,
         value: 0,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "192.0.2.0/24"
-          }
-        ]
+        dimensions: []
       }, {
         metric_name: "reclaimed-leases",
         timestamp: timestamp,
         value: 0,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "192.0.2.0/24"
-          }
-        ]
-      }, {
-        metric_name: "total-addresses",
-        timestamp: timestamp,
-        value: 255,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "192.0.2.0/24"
-          }
-        ]
-      }, {
-        metric_name: "assigned-addresses",
-        timestamp: timestamp,
-        value: 25,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "192.0.2.0/24"
-          }
-        ]
-      }, {
-        metric_name: "assigned-addresses",
-        timestamp: timestamp,
-        value: 10,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "10.0.0.0/8"
-          }
-        ]
-      }, {
-        metric_name: "cumulative-assigned-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions:
-          [
-            {
-              name: "Subnet",
-              value: "10.0.0.0/8"
-            }
-          ]
-      }, {
-        metric_name: "declined-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "10.0.0.0/8"
-          }
-        ]
-      }, {
-        metric_name: "reclaimed-declined-addresses",
-        timestamp: timestamp,
-        value: 0,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "10.0.0.0/8"
-          }
-        ]
-      }, {
-        metric_name: "reclaimed-leases",
-        timestamp: timestamp,
-        value: 0,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "10.0.0.0/8"
-          }
-        ]
-      }, {
-        metric_name: "total-addresses",
-        timestamp: timestamp,
-        value: 512,
-        dimensions:
-        [
-          {
-            name: "Subnet",
-            value: "10.0.0.0/8"
-          }
-        ]
+        dimensions: []
       }, {
         metric_name: "lease-percent-used",
         timestamp: timestamp,
@@ -286,43 +164,6 @@ describe PublishMetrics do
         ]
       }
     ]
-
-    expect(client).to have_received(:put_metric_data).with(expected_result)
-  end
-
-  it 'uses a different task id' do
-
-    kea_stats = JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_stats_response_minimal.json"))
-    result = described_class.new(
-      client: client,
-      kea_lease_usage: kea_lease_usage,
-      kea_subnet_id_to_cidr: kea_subnet_id_to_cidr
-    ).execute(kea_stats: kea_stats)
-
-    expected_result = [
-     {
-      dimensions: [
-        {
-          name: "Subnet",
-          value: "10.0.0.0/8"
-        }
-        ],
-        metric_name: "lease-percent-used",
-        timestamp: timestamp,
-        value: 43
-      },
-      {
-        dimensions: [
-          {
-            name: "Subnet",
-            value:"192.0.2.0/24"
-          }
-        ],
-        metric_name: "lease-percent-used",
-        timestamp: timestamp,
-        value: 50
-        }
-      ]
 
     expect(client).to have_received(:put_metric_data).with(expected_result)
   end


### PR DESCRIPTION
Given the volume of subnets, this won't be displayable in Grafana
because of limits, instead use the aggregated values for the entire
server.

Create a new namespace so the old metrics don't interfere.