### PR TITLE
Move metrics loop out of agent into script

### DIFF
--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -48,7 +48,10 @@ boot_server() {
 
 boot_metrics_agent() {
   echo "Booting metrics agent"
-  ruby ./metrics/boot_metrics_agent.rb &
+  while true; do
+    ruby ./metrics/boot_metrics_agent.rb
+    sleep 10;
+  done &
 }
 
 start_kea_config_reload_daemon(){

--- a/dhcp-service/metrics/boot_metrics_agent.rb
+++ b/dhcp-service/metrics/boot_metrics_agent.rb
@@ -11,11 +11,8 @@ kea_client = KeaClient.new
 kea_subnet_id_to_cidr = KeaSubnetIdToCidr.new(kea_client: kea_client)
 kea_lease_usage = KeaLeaseUsage.new(kea_client: kea_client)
 
-while true do
-  PublishMetrics.new(
-    client: AwsClient.new,
-     kea_lease_usage: kea_lease_usage,
-     kea_subnet_id_to_cidr: kea_subnet_id_to_cidr
-    ).execute(kea_stats: kea_client.get_statistics)
-  sleep 10
-end
+PublishMetrics.new(
+  client: AwsClient.new,
+  kea_lease_usage: kea_lease_usage,
+  kea_subnet_id_to_cidr: kea_subnet_id_to_cidr
+).execute(kea_stats: kea_client.get_statistics)


### PR DESCRIPTION
Currently if the metrics agent runs into an error, it will kill the ruby
process. This means that metrics won't be published.

KEA on first call sometimes returns an empty response when asking for
metrics, this can cause an error on first run.

By moving the loop to the script, the ruby process won't be killed on
error. This error still needs to be addressed.