### PR TITLE
KEA sometimes returns an empty object on first call for metrics

### DIFF
--- a/dhcp-service/metrics/publish_metrics.rb
+++ b/dhcp-service/metrics/publish_metrics.rb
@@ -11,6 +11,8 @@ class PublishMetrics
   def execute(kea_stats:)
     raise "Kea stats are empty" if kea_stats.empty?
 
+    return if kea_stats[0]["arguments"].nil?
+
     client.put_metric_data(
       with_percent_used(generate_cloudwatch_metrics(kea_stats)))
   end

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -50,6 +50,19 @@ describe PublishMetrics do
     }.to raise_error('Kea stats are empty')
   end
 
+  it 'does not publish when the metrics payload does not contain the "arguments" key' do
+    kea_stats = [{}]
+
+    described_class.new(
+      client: client,
+      kea_lease_usage: kea_lease_usage,
+      kea_subnet_id_to_cidr: kea_subnet_id_to_cidr
+    ).execute(kea_stats: kea_stats)
+
+    expect(client).to_not have_received(:put_metric_data)
+  end
+
+
   it 'converts kea stats to cloudwatch metrics and calls the client to publish them' do
     kea_stats = JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_stats_response.json"))
 


### PR DESCRIPTION
Deal with this by skipping the publishing to Cloudwatch, the next loop
will publish the metrics.