### PR TITLE
Only publish metrics from Primary

### DIFF
--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -83,7 +83,7 @@ main() {
   boot_control_agent
   boot_server
   touch /tmp/kea_started
-  if [[ "$SERVER_NAME" == "primary" || "$SERVER_NAME" == "standby" ]]; then
+  if [[ "$PUBLISH_METRICS" == "true" ]]; then
     boot_metrics_agent
   fi
   start_kea_config_reload_daemon


### PR DESCRIPTION
Standby is only used in case of emergency and not really meant to be
observed. The API should not publish metrics at all as it's just used to
validate configurations and list leases.