### PR TITLE
Allow `cmp` to compare configurations without exiting

### DIFF
--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -62,9 +62,11 @@ start_kea_config_reload_daemon(){
     echo "Checking for new configurations..."
     aws s3 sync s3://${KEA_CONFIG_BUCKET_NAME} /tmp/configurations --exclude "*" --include "config.json"
     configure_database_credentials /tmp/configurations/config.json
-    cmp -s /etc/kea/config.json /tmp/configurations/config.json
 
-    if [ $? -ne 0 ]; then
+    status=0
+    cmp -s /etc/kea/config.json /tmp/configurations/config.json || status=$?
+
+    if [ $status -ne 0 ]; then
       echo "Configuration changes detected. Copying in place and updating Kea"
       cp /tmp/configurations/config.json /etc/kea/config.json
       curl -X "POST" "http://localhost:8000/" \


### PR DESCRIPTION
With the set -e, any non-zero return will abort the process.
By assigning the result of the comparison, we are able to use this value
to find out if a configuration reload is required without exiting the
process when cmp returns 1.