### PR TITLE
Fix metrics bug when a subnet has changed in the configuration

### DIFF
--- a/dhcp-service/metrics/kea_subnet_id_to_cidr.rb
+++ b/dhcp-service/metrics/kea_subnet_id_to_cidr.rb
@@ -4,7 +4,13 @@ class KeaSubnetIdToCidr
   end
 
   def execute(subnet_id:)
-    config.find { |row| subnet_id.to_s == row.fetch("id").to_s }["subnet"]
+    result = config.find { |row| subnet_id.to_s == row["id"].to_s }
+
+    if result.nil?
+      p "Subnet #{subnet_id} not found" and return
+    end
+
+    result.fetch("subnet")
   end
 
   private

--- a/dhcp-service/metrics/publish_metrics.rb
+++ b/dhcp-service/metrics/publish_metrics.rb
@@ -51,12 +51,14 @@ class PublishMetrics
   def with_percent_used(metrics)
     kea_lease_usage.execute.each do |kea_metric|
       subnet_cidr = subnet_id_to_cidr(kea_metric.fetch(:subnet_id))
-      metrics << {
-        metric_name: "lease-percent-used",
-        timestamp: @time,
-        value: kea_metric.fetch(:usage_percentage),
-        dimensions: [ { name: "Subnet", value: subnet_cidr } ]
-      }
+      unless subnet_cidr.nil?
+        metrics << {
+          metric_name: "lease-percent-used",
+          timestamp: @time,
+          value: kea_metric.fetch(:usage_percentage),
+          dimensions: [ { name: "Subnet", value: subnet_cidr } ]
+        }
+      end
     end
 
     metrics

--- a/dhcp-service/metrics/spec/fixtures/kea_api_config_get_response.json
+++ b/dhcp-service/metrics/spec/fixtures/kea_api_config_get_response.json
@@ -156,7 +156,7 @@
             "4o6-interface-id":"",
             "4o6-subnet":"",
             "calculate-tee-times":false,
-            "id":1018,
+            "id":2,
             "option-data":[
 
             ],

--- a/dhcp-service/metrics/spec/fixtures/kea_api_stats_response.json
+++ b/dhcp-service/metrics/spec/fixtures/kea_api_stats_response.json
@@ -569,37 +569,73 @@
           "2020-11-09 11:33:29.855132"
         ]
       ],
-      "subnet[1018].cumulative-assigned-addresses": [
+      "subnet[3].cumulative-assigned-addresses": [
         [
           0,
           "2020-11-09 11:33:29.854250"
         ]
       ],
-      "subnet[1018].declined-addresses": [
+      "subnet[3].declined-addresses": [
         [
           0,
           "2020-11-09 11:33:29.855313"
         ]
       ],
-      "subnet[1018].reclaimed-declined-addresses": [
+      "subnet[3].reclaimed-declined-addresses": [
         [
           0,
           "2020-11-09 11:33:29.855317"
         ]
       ],
-      "subnet[1018].reclaimed-leases": [
+      "subnet[3].reclaimed-leases": [
         [
           0,
           "2020-11-09 11:33:29.855322"
         ]
       ],
-      "subnet[1018].total-addresses": [
+      "subnet[3].total-addresses": [
         [
           255,
           "2020-11-09 11:33:29.854247"
         ]
       ],
-      "subnet[1018].assigned-addresses": [
+      "subnet[3].assigned-addresses": [
+        [
+          25,
+          "2020-11-09 11:33:29.854247"
+        ]
+      ],
+      "subnet[2].cumulative-assigned-addresses": [
+        [
+          0,
+          "2020-11-09 11:33:29.854250"
+        ]
+      ],
+      "subnet[2].declined-addresses": [
+        [
+          0,
+          "2020-11-09 11:33:29.855313"
+        ]
+      ],
+      "subnet[2].reclaimed-declined-addresses": [
+        [
+          0,
+          "2020-11-09 11:33:29.855317"
+        ]
+      ],
+      "subnet[2].reclaimed-leases": [
+        [
+          0,
+          "2020-11-09 11:33:29.855322"
+        ]
+      ],
+      "subnet[2].total-addresses": [
+        [
+          255,
+          "2020-11-09 11:33:29.854247"
+        ]
+      ],
+      "subnet[2].assigned-addresses": [
         [
           25,
           "2020-11-09 11:33:29.854247"

--- a/dhcp-service/metrics/spec/kea_subnet_id_to_cidr_spec.rb
+++ b/dhcp-service/metrics/spec/kea_subnet_id_to_cidr_spec.rb
@@ -15,7 +15,13 @@ describe KeaSubnetIdToCidr do
     expected_result = "192.0.2.0/24"
 
     kea_client = double(get_config: JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_config_get_response.json")))
-    result = described_class.new(kea_client: kea_client).execute(subnet_id: 1018)
+    result = described_class.new(kea_client: kea_client).execute(subnet_id: 2)
     expect(result).to eq(expected_result)
+  end
+
+  it "Should return static value for deleted subnet" do
+    kea_client = double(get_config: [{"arguments" => {"Dhcp4" => {"subnet4" => []}}}])
+    result = described_class.new(kea_client: kea_client).execute(subnet_id: 2)
+    expect(result).to be_nil
   end
 end

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -15,7 +15,7 @@ describe PublishMetrics do
         declined_addresses: 0,
         usage_percentage: 43
       }, {
-        subnet_id: 1018,
+        subnet_id: 2,
         assigned_addresses: 2034,
         total_addresses: 4098,
         declined_addresses: 4,


### PR DESCRIPTION
The metrics for subnets are kept in memory. When we change the
configuration file, KEA is unable to find the subnet when it's looping
through the metrics it knows about.

Stop publishing metrics that don't exist in the configuration file.