### PR TITLE
Fix last packet dropped running perfdhcp

### DIFF
--- a/dhcp-service/dhcp_test.sh
+++ b/dhcp-service/dhcp_test.sh
@@ -19,7 +19,7 @@ perfdhcp -r 2 \
          -n $number_of_clients \
          -R $number_of_clients \
          -d 2 \
-         -W 1000000 \
+         -W 20000000 \
          172.1.0.10
 
 echo "Checking leases created..."


### PR DESCRIPTION
# What
Increase the wait time at the end pf the test suite to wait for any remaining packets to be collected. This has been uincreased to 2 seconds to match the drop time (the time before which we consider packets to be lost)

# Why
Once perfdhcp finishes sending packets it will wait for this time to try and finish receiing any leftover packets. On lower performance machiens this packet takes longer and eventually is dropped. The lease is still created in the db but the perf test shows the second half of the DORA cycle as dropped. This may still happen on lower performance machines but should be fixed by a combination of increasing the drop time and the exit wait time