### PR TITLE
Update ha config values to match admin

### DIFF
--- a/dhcp-service/local_development_config.json
+++ b/dhcp-service/local_development_config.json
@@ -115,10 +115,10 @@
             {
               "this-server-name": "<SERVER_NAME>",
               "mode": "hot-standby",
-              "heartbeat-delay": 10,
-              "max-response-delay": 10,
-              "max-ack-delay": 10,
-              "max-unacked-clients": 5,
+              "heartbeat-delay": 10000,
+              "max-response-delay": 60000,
+              "max-ack-delay": 10000,
+              "max-unacked-clients": 0,
               "peers": [
                 {
                   "name": "primary",


### PR DESCRIPTION
# What

Update values to match admin values. See [Admin PR](https://github.com/ministryofjustice/staff-device-dns-dhcp-admin/pull/233)

# Why

"Local" defaults should be the same across repos