### PR TITLE
Install sequel gem for custom lease usage metrics

### DIFF
--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -7,7 +7,7 @@ ARG EXTRA_BUNDLE_CONFIG="without 'test'"
 RUN apk add bash curl mysql mysql-client && \
   curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-1-8/cfg/setup/bash.alpine.sh' |  bash && \
   apk upgrade && \
-  apk add isc-kea-admin isc-kea-perfdhcp isc-kea-dhcp4 isc-kea-ctrl-agent isc-kea-hook-lease-cmds isc-kea-hook-stat-cmds isc-kea-hook-ha && \
+  apk add build-base mysql-dev isc-kea-admin isc-kea-perfdhcp isc-kea-dhcp4 isc-kea-ctrl-agent isc-kea-hook-lease-cmds isc-kea-hook-stat-cmds isc-kea-hook-ha && \
   curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub && \
   curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk && \
   curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk && \

--- a/dhcp-service/metrics/Gemfile
+++ b/dhcp-service/metrics/Gemfile
@@ -4,6 +4,8 @@ source "http://rubygems.org"
 ruby File.read(".ruby-version").chomp
 
 gem "aws-sdk-cloudwatch", "~>1.47"
+gem "sequel", "~> 5.4"
+gem "mysql2", "~> 0.5.3"
 
 group :test do
   gem "rspec"

--- a/dhcp-service/metrics/Gemfile.lock
+++ b/dhcp-service/metrics/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
     diff-lcs (1.4.4)
     hashdiff (1.0.1)
     jmespath (1.4.0)
+    mysql2 (0.5.3)
     public_suffix (4.0.6)
     rexml (3.2.4)
     rspec (3.10.0)
@@ -35,6 +36,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.0)
+    sequel (5.40.0)
     timecop (0.9.2)
     webmock (3.11.1)
       addressable (>= 2.3.6)
@@ -46,7 +48,9 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-cloudwatch (~> 1.47)
+  mysql2 (~> 0.5.3)
   rspec
+  sequel (~> 5.4)
   timecop
   webmock
 


### PR DESCRIPTION
A bug in Kea is preventing us from publishing lease usage metrics
reliably. We need to calculate these values from the database instead
which is the main source of truth.

Add dependencies to support this, actual implementation to follow.