### PR TITLE
Lease usage metrics from database

### DIFF
--- a/dhcp-service/metrics/aws_client.rb
+++ b/dhcp-service/metrics/aws_client.rb
@@ -11,7 +11,7 @@ class AwsClient
   def put_metric_data(metrics)
     sliced(metrics).each do |metrics_slice|
       client.put_metric_data(
-        namespace: "Kea-DHCP-Service",
+        namespace: "Kea-DHCP",
         metric_data: metrics_slice
       )
     end

--- a/dhcp-service/metrics/boot_metrics_agent.rb
+++ b/dhcp-service/metrics/boot_metrics_agent.rb
@@ -4,12 +4,14 @@ require "json"
 require_relative "publish_metrics"
 require_relative "aws_client"
 require_relative "kea_client"
+require_relative "db_client"
 require_relative "kea_lease_usage"
 require_relative "kea_subnet_id_to_cidr"
 
 kea_client = KeaClient.new
+db_client = DbClient.new
 kea_subnet_id_to_cidr = KeaSubnetIdToCidr.new(kea_client: kea_client)
-kea_lease_usage = KeaLeaseUsage.new(kea_client: kea_client)
+kea_lease_usage = KeaLeaseUsage.new(kea_client: kea_client, db_client: db_client)
 
 while true do
   PublishMetrics.new(

--- a/dhcp-service/metrics/db_client.rb
+++ b/dhcp-service/metrics/db_client.rb
@@ -1,0 +1,19 @@
+class DbClient
+  def initialize
+    @db = Sequel.connect(
+      adapter: "mysql2",
+      host: ENV.fetch("DB_HOST"),
+      database: ENV.fetch("DB_NAME"),
+      user: ENV.fetch("DB_USER"),
+      password: ENV.fetch("DB_PASS")
+    )
+  end
+
+  def get_lease_stats
+    db[:lease4_stat].all
+  end
+
+  private
+
+  attr_reader :db
+end

--- a/dhcp-service/metrics/kea_lease_usage.rb
+++ b/dhcp-service/metrics/kea_lease_usage.rb
@@ -1,33 +1,46 @@
+require "sequel"
+
 class KeaLeaseUsage
-  def initialize(kea_client:)
+  def initialize(kea_client:, db_client:)
     @kea_client = kea_client
+    @db_client = db_client
   end
 
   def execute
     lease_stats = kea_client.get_leases
-    parsed_lease_stats = lease_stats[0]["arguments"]["result-set"]["rows"]
+    db_stats = db_client.get_lease_stats
+    in_memory_stats = lease_stats[0]["arguments"]["result-set"]["rows"]
 
-    top_5_lease_stats = parsed_lease_stats.sort_by { |stat| stat[3] }.reverse.first(5)
-
-    top_5_lease_stats.map do |lease_stat|
-      total_addresses = lease_stat[1]
-      assigned_addresses = lease_stat[3]
-
-      {
-        subnet_id: lease_stat[0],
-        total_addresses: total_addresses,
-        assigned_addresses: assigned_addresses,
-        declined_addresses: lease_stat[4],
-        usage_percentage: usage_percent(total_addresses, assigned_addresses)
-      }
-    end
+    all_parsed_metrics(db_stats, in_memory_stats)
+      .compact
+      .sort_by { |metric| - metric[:usage_percentage] }
+      .first(5)
   end
 
   private
+
+  def all_parsed_metrics(db_stats, in_memory_stats)
+    db_stats.map do |db_stat|
+      assigned_addresses = db_stat.fetch(:leases)
+      api_lease_stat = in_memory_stats.find { |lease_stat| lease_stat[0] == db_stat.fetch(:subnet_id) }
+
+      if api_lease_stat
+        total_addresses = api_lease_stat[1]
+
+        {
+          subnet_id: api_lease_stat[0],
+          total_addresses: total_addresses,
+          assigned_addresses: assigned_addresses,
+          declined_addresses: api_lease_stat[4],
+          usage_percentage: usage_percent(total_addresses, assigned_addresses)
+        }
+      end
+    end
+  end
 
   def usage_percent(total_addresses, assigned_addresses)
     ((assigned_addresses.to_f / total_addresses.to_f) * 100).round
   end
 
-  attr_reader :kea_client, :kea_subnet_id_to_cidr
+  attr_reader :kea_client, :kea_subnet_id_to_cidr, :db_client
 end

--- a/dhcp-service/metrics/spec/db_client_spec.rb
+++ b/dhcp-service/metrics/spec/db_client_spec.rb
@@ -1,0 +1,59 @@
+require_relative 'spec_helper'
+require_relative '../db_client'
+require 'sequel'
+
+describe DbClient do
+    before do
+      @db = Sequel.connect(
+        adapter: "mysql2",
+        host: ENV.fetch("DB_HOST"),
+        database: ENV.fetch("DB_NAME"),
+        user: ENV.fetch("DB_USER"),
+        password: ENV.fetch("DB_PASS")
+      )
+    end
+
+  describe 'when there are stats in the db' do
+    before do
+      @db[:lease4_stat].delete
+
+      @db[:lease4_stat].insert(
+        subnet_id: 1,
+        state: 0,
+        leases: 999
+      )
+      @db[:lease4_stat].insert(
+        subnet_id: 2,
+        state: 0,
+        leases: 333
+      )
+    end
+
+    it 'returns the lease stats' do
+      expected_result = [
+        {
+          subnet_id: 1,
+          state: 0,
+          leases: 999
+        }, {
+          subnet_id: 2,
+          state: 0,
+          leases: 333
+        }
+      ]
+
+      expect(subject.get_lease_stats).to eq(expected_result)
+    end
+  end
+
+  describe 'when there are no stats in the db' do
+    before do
+      @db[:lease4_stat].delete
+    end
+
+    it 'returns an empty list' do
+      expected_result = []
+      expect(subject.get_lease_stats).to eq(expected_result)
+    end
+  end
+end

--- a/dhcp-service/metrics/spec/kea_lease_usage_spec.rb
+++ b/dhcp-service/metrics/spec/kea_lease_usage_spec.rb
@@ -4,51 +4,108 @@ require "json"
 
 describe KeaLeaseUsage do
   let(:kea_client) { double(get_leases: JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_stat_lease4_response.json"))) }
-  let(:result) { described_class.new(kea_client: kea_client).execute }
-
-  it "returns leases" do
-    expected_result = [
+  let(:db_client) do
+    double(get_lease_stats: [
       {
-        subnet_id: 3,
-        assigned_addresses: 512,
-        total_addresses: 1024,
-        declined_addresses: 0,
-        usage_percentage: 50
-      },
-      {
-        subnet_id: 5,
-        assigned_addresses: 500,
-        total_addresses: 1024,
-        declined_addresses: 4,
-        usage_percentage: 49
-      },
-      {
-        subnet_id: 4,
-        assigned_addresses: 400,
-        total_addresses: 1024,
-        declined_addresses: 4,
-        usage_percentage: 39
+        subnet_id: 1,
+        state: 0,
+        leases: 100
       },
       {
         subnet_id: 2,
-        assigned_addresses: 200,
-        total_addresses: 1024,
-        declined_addresses: 4,
-        usage_percentage: 20
+        state: 0,
+        leases: 200
       },
       {
-        subnet_id: 1,
-        assigned_addresses: 100,
-        total_addresses: 1024,
-        declined_addresses: 0,
-        usage_percentage: 10
+        subnet_id: 3,
+        state: 0,
+        leases: 512
       },
-    ]
-
-    expect(result).to eq(expected_result)
+      {
+        subnet_id: 4,
+        state: 0,
+        leases: 400
+      },
+      {
+        subnet_id: 5,
+        state: 0,
+        leases: 500
+      },
+      {
+        subnet_id: 6,
+        state: 0,
+        leases: 0
+      }
+    ])
+  end
+  let(:result) do
+    described_class.new(
+      kea_client: kea_client,
+      db_client: db_client
+    ).execute
   end
 
-  it "only selects the top 5 based on usage" do
-    expect(result.count).to eq(5)
+  describe "when the subnets are available in memory stats and the db" do
+    it "returns leases" do
+      expected_result = [
+        {
+          subnet_id: 3,
+          assigned_addresses: 512,
+          total_addresses: 1024,
+          declined_addresses: 0,
+          usage_percentage: 50
+        },
+        {
+          subnet_id: 5,
+          assigned_addresses: 500,
+          total_addresses: 1024,
+          declined_addresses: 4,
+          usage_percentage: 49
+        },
+        {
+          subnet_id: 4,
+          assigned_addresses: 400,
+          total_addresses: 1024,
+          declined_addresses: 4,
+          usage_percentage: 39
+        },
+        {
+          subnet_id: 2,
+          assigned_addresses: 200,
+          total_addresses: 1024,
+          declined_addresses: 4,
+          usage_percentage: 20
+        },
+        {
+          subnet_id: 1,
+          assigned_addresses: 100,
+          total_addresses: 1024,
+          declined_addresses: 0,
+          usage_percentage: 10
+        }
+      ]
+
+      expect(result).to eq(expected_result)
+    end
+
+    it "only selects the top 5 based on usage" do
+      expect(result.count).to eq(5)
+    end
+  end
+
+  describe "when a subnet exists in the db but not the in memory stats" do
+    let(:db_client) do
+      double(get_lease_stats: [
+        {
+          subnet_id: 7,
+          state: 0,
+          leases: 100
+        }
+      ])
+    end
+
+    it "does not publish metrics for that subnet" do
+      expect(result).to eq([])
+    end
   end
 end


### PR DESCRIPTION
We need to calculate these metrics ourselves as Kea sometimes fails to
work this out.

Check the lease4_stat table and use this as the source of truth to
calculate the percentage used.