### PR TITLE
Don't cache in memory Kea configuration

### DIFF
--- a/dhcp-service/metrics/boot_metrics_agent.rb
+++ b/dhcp-service/metrics/boot_metrics_agent.rb
@@ -10,10 +10,11 @@ require_relative "kea_subnet_id_to_cidr"
 
 kea_client = KeaClient.new
 db_client = DbClient.new
-kea_subnet_id_to_cidr = KeaSubnetIdToCidr.new(kea_client: kea_client)
 kea_lease_usage = KeaLeaseUsage.new(kea_client: kea_client, db_client: db_client)
 
 while true do
+  kea_subnet_id_to_cidr = KeaSubnetIdToCidr.new(kea_client: kea_client)
+
   PublishMetrics.new(
     client: AwsClient.new,
     kea_lease_usage: kea_lease_usage,


### PR DESCRIPTION
When a change is made in the Admin portal, the most recent configuration (subnet)
isn't reflected in the metrics. This is due to memoization to optimise
resource utilisation on the server.

Create a new object whenever metrics are published to ensure the most up
to date information is published.