### PR TITLE
Use the metrics namespace defined on the task definition

### DIFF
--- a/dhcp-service/metrics/aws_client.rb
+++ b/dhcp-service/metrics/aws_client.rb
@@ -11,7 +11,7 @@ class AwsClient
   def put_metric_data(metrics)
     sliced(metrics).each do |metrics_slice|
       client.put_metric_data(
-        namespace: "Kea-DHCP",
+        namespace: ENV.fetch("METRICS_NAMESPACE"),
         metric_data: metrics_slice
       )
     end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       PRIMARY_IP: "172.1.0.10"
       STANDBY_IP: "172.1.0.11"
       PUBLISH_METRICS: "true"
+      METRICS_NAMESPACE: "Kea-DHCP"
     ports:
       - 67:67/udp
       - 8000:8000
@@ -84,6 +85,7 @@ services:
       DB_PASS: kea
       DB_HOST: db
       DB_PORT: 3306
+      METRICS_NAMESPACE: "Kea-DHCP"
     depends_on:
       - db
       - dhcp-primary


### PR DESCRIPTION
We are specifying the namespace in 2 places, the infrastructure and this
server. There is a risk that these two can get out of sync.

Use the value defined on the task definition instead.