### PR TITLE
Don't add dimensions to the lease-percent-used metric

### DIFF
--- a/dhcp-service/metrics/publish_metrics.rb
+++ b/dhcp-service/metrics/publish_metrics.rb
@@ -65,10 +65,6 @@ class PublishMetrics
             {
                name: "Subnet",
                value: subnet_cidr
-            },
-            {
-               name: "Server",
-               value: ENV.fetch("SERVER_NAME")
             }
           ]
         }

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -244,9 +244,6 @@ describe PublishMetrics do
             {
               name: "Subnet",
               value: "10.0.0.0/8"
-            }, {
-              name: "Server",
-              value: "primary"
             }
           ]
         }, {
@@ -258,10 +255,6 @@ describe PublishMetrics do
             {
               name: "Subnet",
               value: "192.0.2.0/24"
-            },
-            {
-              name: "Server",
-              value: "primary"
             }
           ]
         }
@@ -286,10 +279,6 @@ describe PublishMetrics do
             {
               name: "Subnet",
               value: "192.0.2.0/24"
-            },
-            {
-              name: "Server",
-              value: "standby"
             }
           ]
         }


### PR DESCRIPTION
This metric is pulled from the database and will always be the same
whether it's published from standby or primary.

Don't add the dimension for the server name which isn't required.