### PR TITLE
Fetch subnet data for both subnets with and without shared networks

### DIFF
--- a/dhcp-service/metrics/kea_subnet_id_to_cidr.rb
+++ b/dhcp-service/metrics/kea_subnet_id_to_cidr.rb
@@ -4,7 +4,7 @@ class KeaSubnetIdToCidr
   end
 
   def execute(subnet_id:)
-    result = config.find { |row| subnet_id.to_s == row["id"].to_s }
+    result = subnets_config.find { |row| subnet_id.to_s == row["id"].to_s }
 
     if result.nil?
       p "Subnet #{subnet_id} not found" and return
@@ -16,7 +16,26 @@ class KeaSubnetIdToCidr
   private
 
   def config
-    @config ||= kea_client.get_config[0]["arguments"]["Dhcp4"]["subnet4"]
+    @config ||= kea_client.get_config[0].fetch("arguments", {})
+  end
+
+
+  def base_subnets_config
+    config.dig("Dhcp4", "subnet4") || []
+  end
+
+  def shared_networks_config
+    config.dig("Dhcp4", "shared-networks") || []
+  end
+
+  def shared_networks_subnets_config
+    shared_networks_config
+      .map { |shared_network| shared_network["subnet4"] }
+      .flatten
+  end
+
+  def subnets_config
+    base_subnets_config + shared_networks_subnets_config
   end
 
   attr_reader :kea_client

--- a/dhcp-service/metrics/spec/fixtures/kea_api_config_get_response.json
+++ b/dhcp-service/metrics/spec/fixtures/kea_api_config_get_response.json
@@ -113,74 +113,113 @@
         },
         "server-hostname":"",
         "server-tag":"",
-        "shared-networks":[
-
-        ],
         "statistic-default-sample-age":0,
         "statistic-default-sample-count":20,
         "store-extended-info":false,
-        "subnet4":[
+        "subnet4": [
           {
-            "4o6-interface":"",
-            "4o6-interface-id":"",
-            "4o6-subnet":"",
-            "calculate-tee-times":false,
-            "id":1,
-            "option-data":[
-
-            ],
-            "pools":[
+            "4o6-interface": "",
+            "4o6-interface-id": "",
+            "4o6-subnet": "",
+            "calculate-tee-times": false,
+            "id": 1,
+            "option-data": [],
+            "pools": [
               {
-                "option-data":[
-
-                ],
-                "pool":"172.1.0.10-172.1.0.100"
+                "option-data": [],
+                "pool": "127.0.0.1 - 127.0.0.254"
               }
             ],
-            "relay":{
-              "ip-addresses":[
-
-              ]
+            "relay": {
+              "ip-addresses": []
             },
-            "reservations":[
-
-            ],
-            "store-extended-info":false,
-            "subnet":"10.0.0.0/8",
-            "t1-percent":0.5,
-            "t2-percent":0.875,
-            "valid-lifetime":4000
+            "reservations": [],
+            "store-extended-info": false,
+            "subnet": "127.0.0.0/24",
+            "t1-percent": 0.5,
+            "t2-percent": 0.875,
+            "valid-lifetime": 4000
+          }
+        ],
+        "shared-networks": [
+          {
+            "name": "test shared network 1",
+            "subnet4": [
+              {
+                "4o6-interface": "",
+                "4o6-interface-id": "",
+                "4o6-subnet": "",
+                "calculate-tee-times": false,
+                "id": 2,
+                "option-data": [],
+                "pools": [
+                  {
+                    "option-data": [],
+                    "pool": "172.1.0.10-172.1.0.100"
+                  }
+                ],
+                "relay": {
+                  "ip-addresses": []
+                },
+                "reservations": [],
+                "store-extended-info": false,
+                "subnet": "10.0.0.0/8",
+                "t1-percent": 0.5,
+                "t2-percent": 0.875,
+                "valid-lifetime": 4000
+              },
+              {
+                "4o6-interface": "",
+                "4o6-interface-id": "",
+                "4o6-subnet": "",
+                "calculate-tee-times": false,
+                "id": 3,
+                "option-data": [],
+                "pools": [
+                  {
+                    "option-data": [],
+                    "pool": "172.1.0.10-172.1.0.100"
+                  }
+                ],
+                "relay": {
+                  "ip-addresses": []
+                },
+                "reservations": [],
+                "store-extended-info": false,
+                "subnet": "192.0.2.0/24",
+                "t1-percent": 0.5,
+                "t2-percent": 0.875,
+                "valid-lifetime": 4000
+              }
+            ]
           },
           {
-            "4o6-interface":"",
-            "4o6-interface-id":"",
-            "4o6-subnet":"",
-            "calculate-tee-times":false,
-            "id":2,
-            "option-data":[
-
-            ],
-            "pools":[
+            "name": "test shared network 2",
+            "subnet4": [
               {
-                "option-data":[
-
+                "4o6-interface": "",
+                "4o6-interface-id": "",
+                "4o6-subnet": "",
+                "calculate-tee-times": false,
+                "id": 4,
+                "option-data": [],
+                "pools": [
+                  {
+                    "option-data": [],
+                    "pool": "172.1.0.10-172.1.0.100"
+                  }
                 ],
-                "pool":"172.1.0.10-172.1.0.100"
+                "relay": {
+                  "ip-addresses": []
+                },
+                "reservations": [],
+                "store-extended-info": false,
+                "subnet": "172.1.0.0/24",
+                "t1-percent": 0.5,
+                "t2-percent": 0.875,
+                "valid-lifetime": 4000
               }
-            ],
-            "relay":{
-              "ip-addresses":[
-
-              ]
-            },
-            "reservations":[
-
-            ],
-            "store-extended-info":false,
-            "subnet":"192.0.2.0/24",
-            "t1-percent":0.5,
-            "t2-percent":0.875,
-            "valid-lifetime":4000
+            ]
           }
         ],
         "t1-percent":0.5,

--- a/dhcp-service/metrics/spec/kea_subnet_id_to_cidr_spec.rb
+++ b/dhcp-service/metrics/spec/kea_subnet_id_to_cidr_spec.rb
@@ -3,25 +3,45 @@ require_relative "../kea_subnet_id_to_cidr"
 require "json"
 
 describe KeaSubnetIdToCidr do
-  it "returns a cidr when given a subnet id" do
-    expected_result = "10.0.0.0/8"
+  context "for subnets not in a shared network" do
+    it "returns a cidr when given a subnet id" do
+      expected_result = "127.0.0.0/24"
 
-    kea_client = double(get_config: JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_config_get_response.json")))
-    result = described_class.new(kea_client: kea_client).execute(subnet_id: 1)
-    expect(result).to eq(expected_result)
+      kea_client = double(get_config: JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_config_get_response.json")))
+      result = described_class.new(kea_client: kea_client).execute(subnet_id: 1)
+      expect(result).to eq(expected_result)
+    end
   end
 
-  it "returns a different cidr when given a subnet id" do
-    expected_result = "192.0.2.0/24"
+  context "for subnets in a shared network" do
+    it "returns a cidr when given a subnet id" do
+      expected_result = "10.0.0.0/8"
 
-    kea_client = double(get_config: JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_config_get_response.json")))
-    result = described_class.new(kea_client: kea_client).execute(subnet_id: 2)
-    expect(result).to eq(expected_result)
-  end
+      kea_client = double(get_config: JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_config_get_response.json")))
+      result = described_class.new(kea_client: kea_client).execute(subnet_id: 2)
+      expect(result).to eq(expected_result)
+    end
 
-  it "Should return static value for deleted subnet" do
-    kea_client = double(get_config: [{"arguments" => {"Dhcp4" => {"subnet4" => []}}}])
-    result = described_class.new(kea_client: kea_client).execute(subnet_id: 2)
-    expect(result).to be_nil
+    it "returns a different cidr when given a subnet id" do
+      expected_result = "192.0.2.0/24"
+
+      kea_client = double(get_config: JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_config_get_response.json")))
+      result = described_class.new(kea_client: kea_client).execute(subnet_id: 3)
+      expect(result).to eq(expected_result)
+    end
+
+    it "returns a different cidr when given a subnet id in a second shared network" do
+      expected_result = "172.1.0.0/24"
+
+      kea_client = double(get_config: JSON.parse(File.read("#{RSPEC_ROOT}/fixtures/kea_api_config_get_response.json")))
+      result = described_class.new(kea_client: kea_client).execute(subnet_id: 4)
+      expect(result).to eq(expected_result)
+    end
+
+    it "Should return nil if there are no subnets" do
+      kea_client = double(get_config: [{"arguments" => {"Dhcp4" => { }}}])
+      result = described_class.new(kea_client: kea_client).execute(subnet_id: 3)
+      expect(result).to be_nil
+    end
   end
 end

--- a/dhcp-service/metrics/spec/publish_metrics_spec.rb
+++ b/dhcp-service/metrics/spec/publish_metrics_spec.rb
@@ -10,16 +10,28 @@ describe PublishMetrics do
     double(execute: [
       {
         subnet_id: 1,
+        assigned_addresses: 10,
+        total_addresses: 256,
+        declined_addresses: 0,
+        usage_percentage: 25.6
+      }, {
+        subnet_id: 2,
         assigned_addresses: 111,
         total_addresses: 256,
         declined_addresses: 0,
         usage_percentage: 43
       }, {
-        subnet_id: 2,
+        subnet_id: 3,
         assigned_addresses: 2034,
         total_addresses: 4098,
         declined_addresses: 4,
         usage_percentage: 50
+      }, {
+        subnet_id: 4,
+        assigned_addresses: 1017,
+        total_addresses: 4098,
+        declined_addresses: 4,
+        usage_percentage: 25
       }
     ])
   end
@@ -238,6 +250,17 @@ describe PublishMetrics do
         }, {
           metric_name: "lease-percent-used",
           timestamp: timestamp,
+          value: 25.6,
+          dimensions:
+          [
+            {
+              name: "Subnet",
+              value: "127.0.0.0/24"
+            }
+          ]
+        }, {
+          metric_name: "lease-percent-used",
+          timestamp: timestamp,
           value: 43,
           dimensions:
           [
@@ -255,6 +278,17 @@ describe PublishMetrics do
             {
               name: "Subnet",
               value: "192.0.2.0/24"
+            }
+          ]
+        }, {
+          metric_name: "lease-percent-used",
+          timestamp: timestamp,
+          value: 25,
+          dimensions:
+          [
+            {
+              name: "Subnet",
+              value: "172.1.0.0/24"
             }
           ]
         }


### PR DESCRIPTION
Allow the metrics exporter to publish metrics for subnets both with and without shared networks. This is backwards compatible with the old configuration file format. 