### PR TITLE
:wrench: create-codeowners-file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/cloud-ops-admins @ministryofjustice/moj-official-techops
+* @ministryofjustice/cloud-ops-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/cloud-ops-admins @ministryofjustice/moj-official-techops


### PR DESCRIPTION
Create CODEOWNERS file containing 'cloud-ops-admins' and 'moj-official-techops' teams to improve GibHub branch protection rules.