### PR TITLE
:arrow_down: downgrade kea to stable version 2.0.2

### DIFF
--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -4,7 +4,7 @@ ENV GLIBC_VER=2.34-r0
 ARG EXTRA_BUNDLE_CONFIG="without 'test'"
 
 RUN apk add bash curl mysql mysql-client && \
-  curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-2-1/setup.alpine.sh' |  bash && \
+  curl -1sLf 'https://dl.cloudsmith.io/public/isc/kea-2-0/setup.alpine.sh' |  bash && \
   apk upgrade && \
   apk add build-base mysql-dev isc-kea-admin isc-kea-perfdhcp isc-kea-dhcp4 isc-kea-ctrl-agent isc-kea-hook-lease-cmds isc-kea-hook-stat-cmds isc-kea-hook-ha && \
   curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub && \

--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -42,6 +42,10 @@ init_schema_if_not_loaded() {
   fi
 }
 
+temporary_schema_fix() {
+  mysql -u ${DB_USER} -p${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} -e "update schema_version set version = 12, minor = 0 where 1;"
+}
+
 upgrade_db_if_required() {
 $(kea-admin db-upgrade mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} &> /dev/null)
 }
@@ -98,6 +102,7 @@ main() {
     ensure_database_permissions
   fi
   init_schema_if_not_loaded
+  temporary_schema_fix
   upgrade_db_if_required
   boot_control_agent
   boot_server


### PR DESCRIPTION
also sets schema version back to 12 from 13