### PR TITLE
🔥 Stop upgrade_db_if_required output to /dev/null

### DIFF
--- a/dhcp-service/bootstrap.sh
+++ b/dhcp-service/bootstrap.sh
@@ -43,7 +43,7 @@ init_schema_if_not_loaded() {
 }
 
 upgrade_db_if_required() {
-$(kea-admin db-upgrade mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST} &> /dev/null)
+$(kea-admin db-upgrade mysql -u ${DB_USER} -p ${DB_PASS} -n ${DB_NAME} -h ${DB_HOST})
 }
 
 ensure_database_permissions() {


### PR DESCRIPTION
This stops upgrade_db_if_required sending its output to /dev/null. 

This is removing detail needed when troubleshooting.