### PR TITLE
♻ Remove SHARED_SERVICES_ACCOUNT_ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 AWS_PROFILE=mojo-shared-services-cli
-SHARED_SERVICES_ACCOUNT_ID=
 REGISTRY_URL=
 ENV=


### PR DESCRIPTION
This is no longer required since moving from ECR to Docker Hub