### PR TITLE
:wrench: Update Sentry gem environment call

### DIFF
--- a/dhcp-service/metrics/Gemfile
+++ b/dhcp-service/metrics/Gemfile
@@ -6,10 +6,13 @@ ruby File.read(".ruby-version").chomp
 gem "aws-sdk-cloudwatch", "~>1.66"
 gem "sequel", "~> 5.60"
 gem "mysql2", "~> 0.5.4"
-gem "sentry-ruby"
 
 group :test do
   gem "rspec"
   gem "timecop"
   gem "webmock"
+end
+
+group :production do
+  gem "sentry-ruby"
 end

--- a/dhcp-service/metrics/Gemfile.lock
+++ b/dhcp-service/metrics/Gemfile.lock
@@ -59,7 +59,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.0.3p157
 
 BUNDLED WITH
-   2.1.4
+   2.2.32

--- a/dhcp-service/metrics/boot_metrics_agent.rb
+++ b/dhcp-service/metrics/boot_metrics_agent.rb
@@ -6,10 +6,12 @@ require_relative "publish_metrics"
 require_relative "aws_client"
 require_relative "kea_client"
 
-Sentry.init do |config|
-  # All errors will be sent syncronously!
-  config.background_worker_threads = 0
-  config.environment = ENV["SENTRY_CURRENT_ENV"]
+if ENV["SENTRY_DSN"]
+  Sentry.init do |config|
+    # All errors will be sent syncronously!
+    config.background_worker_threads = 0
+    config.environment = ENV["SENTRY_CURRENT_ENV"]
+  end
 end
 
 class Agent
@@ -23,7 +25,9 @@ class Agent
       sleep 10
     end
   rescue => e
-    Sentry.capture_exception(e)
+    if ENV["SENTRY_DSN"]
+      Sentry.capture_exception(e)
+    end
     raise e
   end
 


### PR DESCRIPTION
The purpose of this PR is to resolve [this](https://github.com/ministryofjustice/staff-device-dhcp-server/issues/197) issue in which the workaround is to remove the `sentry-ruby` gem when running tests locally. 

The PR alters the Gemfile so that the `sentry-ruby` gem is only called in production, as such the workaround is no longer required. 

✅ Tests passed with this configuration. 