### PR TITLE
:wrench: Update Alpine Image version

### DIFF
--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-alpine3.14
+FROM ruby:3.1.2-alpine3.15
 
 ENV GLIBC_VER=2.34-r0
 ARG EXTRA_BUNDLE_CONFIG="without 'test'"


### PR DESCRIPTION
This PR upgrades Alpine from `3.14` -> `3.15`.

Tests have passed successfully locally. 