### PR TITLE
:wrench: Upgrade glibc: 2.34 -> 2.35

### DIFF
--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:3.1.2-alpine3.14
+FROM ruby:3.1.2-alpine3.15
 
-ENV GLIBC_VER=2.34-r0
+ENV GLIBC_VER=2.35-r0
 ARG EXTRA_BUNDLE_CONFIG="without 'test'"
 
 RUN apk add bash curl mysql mysql-client && \


### PR DESCRIPTION
This PR upgrade glibc: `2.34` -> `2.35`. This PR should be merged after [this](https://github.com/ministryofjustice/staff-device-dhcp-server/pull/242) PR which upgrades Alpine 

I've tested it with Alpine 3.15 and I'm just creating this PR in advance. 