### PR TITLE
Revert ":wrench: Upgrade glibc: 2.34 -> 2.35"

### DIFF
--- a/dhcp-service/Dockerfile
+++ b/dhcp-service/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.1.2-alpine3.15
 
-ENV GLIBC_VER=2.35-r0
+ENV GLIBC_VER=2.34-r0
 ARG EXTRA_BUNDLE_CONFIG="without 'test'"
 
 RUN apk add bash curl mysql mysql-client && \


### PR DESCRIPTION
Reverts ministryofjustice/staff-device-dhcp-server#243

We are seeing errors of the form: 

```
2023-01-12T16:51:08.021+00:00CopyError relocating /usr/local/bin/aws: __strcat_chk: symbol not found | Error relocating /usr/local/bin/aws: __strcat_chk: symbol not found
-- | --
  | 2023-01-12T16:51:08.021+00:00 | Error relocating /usr/local/bin/aws: __snprintf_chk: symbol not found
  | 2023-01-12T16:51:08.021+00:00 | Error relocating /usr/local/bin/aws: __vfprintf_chk: symbol not found
  | 2023-01-12T16:51:08.021+00:00 | Error relocating /usr/local/bin/aws: __realpath_chk: symbol not found
  | 2023-01-12T16:51:08.021+00:00 | Error relocating /usr/local/bin/aws: __strdup: symbol not found
  | 2023-01-12T16:51:08.021+00:00 | Error relocating /usr/local/bin/aws: __memcpy_chk: symbol not found
  | 2023-01-12T16:51:08.021+00:00 | Error relocating /usr/local/bin/aws: __vsnprintf_chk: symbol not found
  | 2023-01-12T16:51:08.021+00:00 | Error relocating /usr/local/bin/aws: __strcpy_chk: symbol not found
  | 2023-01-12T16:51:08.021+00:00 | Error relocating /usr/local/bin/aws: __fprintf_chk: symbol not found

```