### PR TITLE
M1chipfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env
 .vscode
 *.pcap
+.idea
+staff-device-dhcp-server
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .vscode
 *.pcap
 .idea
-staff-device-dhcp-server
+
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   dhcp-primary:
+    platform: linux/amd64
     build:
       context: ./dhcp-service
     depends_on:
@@ -29,6 +30,7 @@ services:
         ipv4_address: 172.1.0.10
 
   dhcp-standby:
+    platform: linux/amd64
     build:
       context: ./dhcp-service
     environment:
@@ -50,6 +52,7 @@ services:
         ipv4_address: 172.1.0.11
 
   dhcp-api:
+    platform: linux/amd64
     build:
       context: ./dhcp-service
     environment:
@@ -68,6 +71,7 @@ services:
       - ./dhcp-service/metrics/:/metrics
 
   dhcp-test:
+    platform: linux/amd64
     build:
       context: ./dhcp-service
       dockerfile: Dockerfile.test
@@ -91,6 +95,7 @@ services:
 
   db:
     image: "mysql:5.7"
+    platform: linux/amd64
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
Added fix for error "no matching manifest for linux/arm64/v8 in the manifest list entries" is because of the Apple Silicon M1 chip which does not support some images.