### PR TITLE
Removed Make initiation of absent target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ build-dev: ## Build dev image
 
 .PHONY: start-db
 start-db: ## start database
-	$(MAKE) check-container-registry-account-id
 	$(DOCKER_COMPOSE) up -d db
 	./scripts/wait_for_db.sh
 


### PR DESCRIPTION
the target
	##$(MAKE) check-container-registry-account-id
does not exist in the Makefile and test stage failed. Removing as it must have been deprecated before.