### PR TITLE
removed wait script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ stop: ## Stop and remove containers
 .PHONY: run
 run: ## Build dev image and start dhcp container
 	$(DOCKER_COMPOSE) up -d dhcp-primary
-	./scripts/wait_for_dhcp_server.sh
 	$(DOCKER_COMPOSE) up -d dhcp-standby
 	$(DOCKER_COMPOSE) up -d dhcp-api
 


### PR DESCRIPTION
On this commit we removed the wait script due to moving the logic to docker compose:

https://github.com/ministryofjustice/staff-device-dhcp-server/commit/68629c0e05c3ed7abf2714df1f2aed3cd856a7da#diff-d14ae6be75bed6f002ba988a6889c36f2d0a975f2b97014a8d11a74791fdc06c

However we missed removing the wait from make run 